### PR TITLE
record.py: regard noupdate in ensure_xmlid_match_record

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -782,10 +782,17 @@ class TestRecords(UnitTestCase):
         newtx1 = util.ref(cr, "base.TX1")
         self.assertEqual(newtx1, tx1.id)
 
-        # break one res_id
-        cr.execute("UPDATE ir_model_data SET res_id=%s WHERE module='base' AND name='TX1'", [tx2.id])
+        # break one res_id, with noupdate
+        cr.execute("UPDATE ir_model_data SET res_id=%s,noupdate=TRUE WHERE module='base' AND name='TX1'", [tx2.id])
 
-        # case: `base.TX1` points to ResCurrency(169) but doesn't match values {'name': 'TX3'}; no other matches found.
+        # case: NO update `base.TX1` from res.currency(168) to res.currency(169); values {'name': 'TX1'}
+        ensured_id = util.ensure_xmlid_match_record(cr, "base.TX1", "res.currency", {"name": "TX1"})
+        self.assertEqual(ensured_id, tx2.id)
+
+        # reset noupdate
+        cr.execute("UPDATE ir_model_data SET noupdate=FALSE WHERE module='base' AND name='TX1'")
+
+        # case: `base.TX1` refers res.currency(169); values differ {'name': 'TX3'}; no other match found.
         ensured_id = util.ensure_xmlid_match_record(cr, "base.TX1", "res.currency", {"name": "TX3"})
         self.assertEqual(ensured_id, tx2.id)
 
@@ -797,7 +804,7 @@ class TestRecords(UnitTestCase):
         ensured_id = util.ensure_xmlid_match_record(cr, "base.TX4", "res.currency", {"name": "TX4"})
         self.assertIsNone(ensured_id)
 
-        # case: update `base.TX1` to point to ResCurrency(168) instead of ResCurrency(169); matching values {'name': 'TX1'}
+        # case: update `base.TX1` from res.currency(168) to res.currency(169); values {'name': 'TX1'}
         ensured_id = util.ensure_xmlid_match_record(cr, "base.TX1", "res.currency", {"name": "TX1"})
         self.assertEqual(ensured_id, tx1.id)
 
@@ -808,7 +815,7 @@ class TestRecords(UnitTestCase):
         cr.execute("DELETE FROM ir_model_data WHERE module='base' AND name='TX1'")
         self.assertIsNone(util.ref(cr, "base.TX1"))
 
-        # case: create `base.TX1` that point to ResCurrency(168); matching values {'name': 'TX1'}
+        # case: create `base.TX1` that point to res.currency(168); matching values {'name': 'TX1'}
         ensured_id = util.ensure_xmlid_match_record(cr, "base.TX1", "res.currency", {"name": "TX1"})
         self.assertEqual(ensured_id, tx1.id)
 


### PR DESCRIPTION
The change in f8c41cc7a4c8314dc31c6415a98be512c90c522c introduced additional `ir_model_data` updates for rows that point to an existing record that doesn't match the values used to lookup a suitable record, if such a matching record exists. It will update the row in that case not regarding the `noupdate` column.
    
Tune this behavior by adding an additional check that returns immediately with the original `res_id`, if an `ir_model_data` row for the xmlid exists that points to an existing record and the `noupdate` column is `True`. This way, the update for existing, non-matching records will only happen if `noupdate` is `False`.

Also, in a second commit, add a test for this.

This was https://github.com/odoo/upgrade/pull/4793, already approved there by @aj-fuentes but not merged in time for the utils extraction.