### PR TITLE
[IMP] util/records: prepare arch for parser also for jsonb arch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ line-length = 120
 fix = true
 show-fixes = true
 ignore = [
+    "B904",  # raise-without-from-inside-except; not python2 compatible
     "B905",  # zip-without-explicit-strict; not python2 compatible
     "E501",  # line-too-long; handled by `black` formatting
     "E731",  # lambda-assignment

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -199,6 +199,11 @@ def edit_view(cr, xmlid=None, view_id=None, skip_if_not_noupdate=True, active=Tr
         )
         [arch] = cr.fetchone() or [None]
         if arch:
+
+            def parse(arch):
+                arch = arch.encode("utf-8") if isinstance(arch, unicode) else arch
+                return lxml.etree.fromstring(arch.replace(b"&#13;\n", b"\n"))
+
             if jsonb_column:
 
                 def get_trans_terms(value):
@@ -207,7 +212,7 @@ def edit_view(cr, xmlid=None, view_id=None, skip_if_not_noupdate=True, active=Tr
                     return terms
 
                 translation_terms = {lang: get_trans_terms(value) for lang, value in arch.items()}
-                arch_etree = lxml.etree.fromstring(arch["en_US"])
+                arch_etree = parse(arch["en_US"])
                 yield arch_etree
                 new_arch = lxml.etree.tostring(arch_etree, encoding="unicode")
                 terms_en = translation_terms["en_US"]
@@ -218,9 +223,7 @@ def edit_view(cr, xmlid=None, view_id=None, skip_if_not_noupdate=True, active=Tr
                     }
                 )
             else:
-                if isinstance(arch, unicode):
-                    arch = arch.encode("utf-8")
-                arch_etree = lxml.etree.fromstring(arch.replace(b"&#13;\n", b"\n"))
+                arch_etree = parse(arch)
                 yield arch_etree
                 arch_column_value = lxml.etree.tostring(arch_etree, encoding="unicode")
 


### PR DESCRIPTION
In a recent commit c7c95cfc8ee2f955413fd1f89cc6dd56a9d14b7a, some code to fixup views in preparation for the `lxml.etree` parser has been added to `edit_vew()`. So far, it only happens in the code path for non-jsonb columns. This patch introduces a sub-function and calls it from both the code branch for jsonb and non-jsonb.