### PR TITLE
[FIX] util: Restore compatibility with 7.0

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -9,7 +9,12 @@ try:
     from contextlib import suppress
 except ImportError:
     # python2 code, use the openerp vendor
-    from openerp.tools.misc import ignore as suppress
+    try:
+        from openerp.tools.misc import ignore as suppress
+    except ImportError:
+        # this is to allow v7.0 DBs to import this module without errors
+        # note: some functions on this module will fail (like adapt_domains)
+        suppress = None
 
 try:
     from html import unescape

--- a/src/util/orm.py
+++ b/src/util/orm.py
@@ -196,6 +196,8 @@ def invalidate(records, *args):
 
 
 def no_selection_cache_validation(f=None):
+    if not version_gte("8.0"):
+        return f
     old_convert = ofields.Selection.convert_to_cache
 
     def _convert(self, value, record, validate=True):


### PR DESCRIPTION
Some of the utils use code that is not available in 7.0, which results in a crash when starting a <=7.0 database.

Issue No.1:

When the module `runsanitizer` is loaded, Odoo is trying to import `env()` from util/orm.py. There is a [check](https://github.com/odoo/upgrade-util/blob/f1f3ca29b199c37c9301a530073b0fc1747be188/src/util/orm.py#L23) to ensure that `openerp.fields`, which was introduced in 8.0, is not being read by earlier versions and set to None instead.
While parsing orm.py however, any decorators are evaluated including `no_selection_cache_validation()`, which assumes that `openerp.fields` has been imported, and fails on an AttributeError.
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/7.0/openerp/cli/server.py", line 97, in preload_registry
    db, registry = openerp.pooler.get_db_and_pool(dbname,update_module=update_module)
  File "/home/odoo/src/odoo/7.0/openerp/pooler.py", line 33, in get_db_and_pool
    registry = RegistryManager.get(db_name, force_demo, status, update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/registry.py", line 203, in get
    update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/registry.py", line 233, in new
    openerp.modules.load_modules(registry.db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/loading.py", line 355, in load_modules
    loaded_modules, update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/loading.py", line 256, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
  File "/home/odoo/src/odoo/7.0/openerp/modules/loading.py", line 159, in load_module_graph
    load_openerp_module(package.name)
  File "/home/odoo/src/odoo/7.0/openerp/modules/module.py", line 405, in load_openerp_module
    __import__('openerp.addons.' + module_name)
  File "/home/odoo/src/odoo/7.0/openerp/modules/module.py", line 133, in load_module
    mod = imp.load_module('openerp.addons.' + module_part, f, path, descr)
  File "/home/odoo/bin/addons/runsanitizer/__init__.py", line 14, in <module>
    from openerp.addons.base.maintenance.migrations import util
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/__init__.py", line 3, in <module>
    from .data import *
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/data.py", line 6, in <module>
    from .records import ref
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/records.py", line 27, in <module>
    from .orm import env
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/orm.py", line 216, in <module>
    def recompute_fields(cr, model, fields, ids=None, logger=_logger, chunk_size=256, strategy="auto"):
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/orm.py", line 199, in no_selection_cache_validation
    old_convert = ofields.Selection.convert_to_cache
AttributeError: 'NoneType' object has no attribute 'Selection'
```
A check at the top of the decorator fixes that (it was already [anticipated](https://github.com/odoo/upgrade-util/blob/f1f3ca29b199c37c9301a530073b0fc1747be188/src/util/orm.py#L25) that the decorated function `recompute_fields` would not work in 7.0).

---

Issue No. 2:

Importing util leads to importing everything from util/domains, including `ignore()` from opernerp.tools.misc which got introduced after 7.0.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/7.0/openerp/cli/server.py", line 97, in preload_registry
    db, registry = openerp.pooler.get_db_and_pool(dbname,update_module=update_module)
  File "/home/odoo/src/odoo/7.0/openerp/pooler.py", line 33, in get_db_and_pool
    registry = RegistryManager.get(db_name, force_demo, status, update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/registry.py", line 203, in get
    update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/registry.py", line 233, in new
    openerp.modules.load_modules(registry.db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/loading.py", line 355, in load_modules
    loaded_modules, update_module)
  File "/home/odoo/src/odoo/7.0/openerp/modules/loading.py", line 256, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
  File "/home/odoo/src/odoo/7.0/openerp/modules/loading.py", line 159, in load_module_graph
    load_openerp_module(package.name)
  File "/home/odoo/src/odoo/7.0/openerp/modules/module.py", line 405, in load_openerp_module
    __import__('openerp.addons.' + module_name)
  File "/home/odoo/src/odoo/7.0/openerp/modules/module.py", line 133, in load_module
    mod = imp.load_module('openerp.addons.' + module_part, f, path, descr)
  File "/home/odoo/bin/addons/runsanitizer/__init__.py", line 14, in <module>
    from openerp.addons.base.maintenance.migrations import util
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/__init__.py", line 4, in <module>
    from .domains import *
  File "/home/odoo/src/odoo/7.0/openerp/addons/base/maintenance/migrations/util/domains.py", line 12, in <module>
    from openerp.tools.misc import ignore as suppress
ImportError: cannot import name ignore
```

We change the ignore import to fallback to None if not found, so that the rest of the util import can continue (like we already do in for the ofields import in orm.py, introduced in e321b127851281bc7a313c0ad2b27736e981fd98).