### PR TITLE
[FIX] records: remove double quote_ident

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -505,7 +505,7 @@ def remove_group(cr, xml_id=None, group_id=None):
         return
 
     # Get all fks from table res_groups
-    fks = get_fk(cr, "res_groups")
+    fks = get_fk(cr, "res_groups", quote_ident=False)
 
     # Remove records referencing the group_id from the referencing tables (restrict fks)
     standard_tables = ["ir_model_access", "rule_group_rel"]


### PR DESCRIPTION
The results of get_fk are quote_idented by [default](https://github.com/odoo/upgrade-util/blob/7681facc4492d71720efaf587aaa10b03ae9b154/src/util/pg.py#L435). Adding more quotes may result in sql syntax errors when the table names or column names are not standard.

affects upg-1172577
```
psycopg2.errors.SyntaxError: zero-length delimited identifier at or near """"
LINE 1: SELECT COUNT(*) FROM "groups_team" WHERE ""groupID"" = 79
                                                 ^
```