### PR TITLE
[FIX] util/const : track rename field for view_fixer

### DIFF
--- a/src/util/const.py
+++ b/src/util/const.py
@@ -11,6 +11,7 @@ except ImportError:
 # migration environ, used to share data between scripts
 ENVIRON = {
     "__renamed_fields": collections.defaultdict(dict),
+    "__temp_rename_update_ref": collections.defaultdict(dict),
     "__modules_auto_discovery_force_installs": set(),
     "__modules_auto_discovery_force_upgrades": {},
     "__fix_fk_allowed_cascade": [],


### PR DESCRIPTION
This store the field name being renamed using  update_field_usage/references method for the view_fixer
we store field name in a temporary constant __temp_rename_update_ref and once the old field is removed we transfer it into __renamed_fields to add a safety check also avoid any unforeseen issues.