### PR TITLE
[FIX] base/0.0.0/post-commercial_partner_id: Fix Memory Error

### DIFF
--- a/src/base/0.0.0/post-commercial_partner_id.py
+++ b/src/base/0.0.0/post-commercial_partner_id.py
@@ -5,6 +5,40 @@ from odoo.addons.base.maintenance.migrations import util
 def migrate(cr, version):
     # The `commercial_partner_id` field is expected to always be set. Although the column is not marked as `NOT NULL`.
     # Fight the Murphy's Law, and recompute the value on partners with a NULL value.
-    cr.execute("SELECT id FROM res_partner WHERE commercial_partner_id IS NULL")
+    cr.execute("SELECT 1 FROM res_partner WHERE commercial_partner_id IS NULL LIMIT 1")
     if cr.rowcount:
-        util.recompute_fields(cr, "res.partner", ["commercial_partner_id"], ids=[id_ for id_, in cr.fetchall()])
+        cr.execute(
+            """
+            WITH RECURSIVE partner AS (
+                SELECT id as cid,
+                        ARRAY[id] AS path
+                  FROM res_partner
+                 WHERE parent_id is null
+                 GROUP BY parent_id,id
+
+                 UNION ALL
+
+                SELECT child.id as cid,
+                        ARRAY_PREPEND(child.id,parent.path) AS path
+                  FROM partner AS parent
+                  JOIN res_partner child
+                    ON child.parent_id = parent.cid
+            )
+            UPDATE res_partner rp
+               SET commercial_partner_id = pat.path[array_length(path, 1)]
+              FROM partner pat
+             WHERE pat.cid = rp.id
+               AND (
+                    is_company = 'f' OR is_company IS NULL
+                    )
+            """
+        )
+        util.explode_execute(
+            cr,
+            """
+            UPDATE res_partner
+               SET commercial_partner_id = id
+             WHERE is_company = 't'
+            """,
+            table="res_partner",
+        )


### PR DESCRIPTION
```
select count(id) from res_partner;
  count
----------
 29977897
```
If the records of the 'res_partner' table are in millions then the list will out of memory ``` [id_ for id_, in cr.fetchall()] ``` and will leads to memory error. So for avoiding this issue computing [commercial_partner_id](https://github.com/odoo/odoo/blob/e3255ba8570933f2843abcb319a271b1a94918cc/odoo/addons/base/models/res_partner.py#L415) by sql.
demo data
before fix
```
 select * from res_partner order by id;
 id | parent_id | commercial_partner_id | is_company
----+-----------+-----------------------+------------
  1 |         2 |                       | t
  2 |         3 |                       |
  3 |         4 |                       |
  4 |         7 |                       | f
  5 |         6 |                       |
  6 |         7 |                       | f
  7 |           |                       | f
```

after fix
```
 select * from res_partner order by id;
 id | parent_id | commercial_partner_id | is_company
----+-----------+-----------------------+------------
  1 |         2 |                     1 | t
  2 |         3 |                     7 |
  3 |         4 |                     7 |
  4 |         7 |                     7 | f
  5 |         6 |                     7 |
  6 |         7 |                     7 | f
  7 |           |                     7 | f
```
I haven't use when case to do in single query because it taking lot of time approx 13hours that is why seperated in two query