### PR TITLE
[IMP] tests: avoid duplicate tests

### DIFF
--- a/src/testing.py
+++ b/src/testing.py
@@ -95,6 +95,7 @@ class UpgradeCommon(BaseCase):
 
     change_version = (None, None)
     _abstract = True
+    allow_inherited_tests_method = True
 
     @property
     def key(self):


### PR DESCRIPTION
Linked to odoo/odoo#148660

In the corresponding community pr, a test is not executed twice when importing a testClass, a common mistake when writing tests.

Upgrade tests were relying on this side effect to run tests. A flag is added on the class to enable this behavior in this case only.