### PR TITLE
[ADD] util/specific.py: add helper to rename module

### DIFF
--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -3,6 +3,7 @@ import logging
 
 from .helpers import _validate_table
 from .misc import _cached
+from .modules import rename_module
 from .pg import column_exists, rename_table
 from .report import add_to_migration_reports
 
@@ -40,6 +41,17 @@ def dispatch_by_dbuuid(cr, version, callbacks):
         func = callbacks[uuid]
         _logger.info("calling dbuuid-specific function `%s`", func.__name__)
         func(cr, version)
+
+
+def rename_custom_module(cr, old_module_name, new_module_name, report_details=""):
+    rename_module(cr, old_module_name, new_module_name)
+
+    add_to_migration_reports(
+        category="Custom modules",
+        message="The custom module '{old_module_name}' was renamed to '{new_module_name}'. {report_details}".format(
+            **locals()
+        ),
+    )
 
 
 def rename_custom_table(


### PR DESCRIPTION
Whenever we changes the custom module name every time we have to add migration report statically for reducing line of code [reference](https://github.com/odoo/upgrade-util/commit/7786de7d7f4e8333553b3d62b2451fe43d5f838a).