### PR TITLE
[FIX] util/convert_bootstrap: ignore `DeprecationWarning` from distutils

### DIFF
--- a/src/util/convert_bootstrap.py
+++ b/src/util/convert_bootstrap.py
@@ -8,11 +8,7 @@ from typing import Iterable
 
 from lxml import etree
 
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import StrictVersion as Version  # N.B. deprecated, will be removed in py3.12
-
+from .misc import parse_version as Version
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When we upgrade from version 15 to 16 we get a `DeprecationWarning` due to python version change. So this fix aims to ignore it for the purpose of log improvement.

warning : 
```bash
2024-02-27 08:47:45,281 2015 WARNING db_test py.warnings: /tmp/tmpsqmjb915/migrations/util/convert_bootstrap.py:973: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  File "/home/odoo/src/odoo/16.0/odoo-bin", line 8, in <module>
    odoo.cli.main()
  File "/home/odoo/src/odoo/16.0/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/home/odoo/src/odoo/16.0/odoo/cli/server.py", line 180, in run
    main(args)
  File "/home/odoo/src/odoo/16.0/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/home/odoo/src/odoo/16.0/odoo/service/server.py", line 1399, in start
    rc = server.run(preload, stop)
  File "/home/odoo/src/odoo/16.0/odoo/service/server.py", line 579, in run
    rc = preload_registries(preload)
  File "/home/odoo/src/odoo/16.0/odoo/service/server.py", line 1299, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/16.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/16.0/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 429, in load_modules
    loaded_modules, processed_modules = load_module_graph(
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 183, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/home/odoo/src/odoo/16.0/odoo/modules/migration.py", line 189, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmpsqmjb915/migrations/base/16.0.1.3/pre-90-convert-bootstrap5.py", line 196, in migrate
    convert_views(cr)
  File "/tmp/tmpsqmjb915/migrations/base/16.0.1.3/pre-90-convert-bootstrap5.py", line 62, in convert_views
    is_bs = get_bs5_where_clause(cr, "v.arch_db")
  File "/tmp/tmpsqmjb915/migrations/base/16.0.1.3/pre-90-convert-bootstrap5.py", line 154, in get_bs5_where_clause
    classes, other_kwds = get_keyword_list()
  File "/tmp/tmpsqmjb915/migrations/base/16.0.1.3/pre-90-convert-bootstrap5.py", line 115, in get_keyword_list
    conversions = BootstrapConverter.get_conversions("4.0", "5.0")
  File "/tmp/tmpsqmjb915/migrations/util/convert_bootstrap.py", line 973, in get_conversions
    if Version(dst_ver) < Version(src_ver):
 ```