### PR TITLE
[IMP] util/modules: remove `ir.asset`s

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -38,7 +38,7 @@ from .helpers import _validate_model, table_of_model
 from .misc import on_CI, str2bool, version_gte
 from .models import delete_model
 from .orm import env, flush
-from .pg import column_exists, table_exists, target_of
+from .pg import column_exists, format_query, table_exists, target_of
 from .records import ref, remove_menus, remove_records, remove_view, replace_record_references_batch
 
 INSTALLED_MODULE_STATES = ("installed", "to install", "to upgrade")
@@ -152,6 +152,17 @@ def uninstall_module(cr, module):
 
     if menu_ids:
         remove_menus(cr, menu_ids)
+
+    if table_exists(cr, "ir_asset"):
+        field_name = "path" if column_exists(cr, "ir_asset", "path") else "glob"
+        cr.execute(
+            format_query(
+                cr,
+                "DELETE FROM ir_asset WHERE {} ~ ('^/?' || %s || '/')",
+                field_name,
+            ),
+            [module],
+        )
 
     # remove relations
     cr.execute(


### PR DESCRIPTION
DISCLAIMER: I don't think this change is necessary or at least I couldn't find any evidence to support that. Publishing to have a track record of this.

### What was this all about? 

To make sure that `ir.asset`s from a module were removed during the corresponding module's removal, avoiding  the necessity for [this](https://github.com/odoo/upgrade-specific/blob/1ff80c1e7bc63df34de43d858490857098ba8f54/scripts/M240118118487471/base/17.0.1.0/pre-migrate.py#L70). 

### Do we generally need this?

No, because `ir.asset`s, just like any other declared records are associated an imd and are thus removed [here](https://github.com/odoo/upgrade-util/blob/6c3fab7f601f18cfa863bdd88cc7f13886f72b09/src/util/modules.py#L149).

In fact, it turns out that the linked manual removal of assets was only required to remove assets from custom modules, which were not assigned an imd. Something that these utils are not generally supposed to take into account.

Empirical evidence:

```SQL
odoo@(none):test_assets2> SELECT COUNT(*) FROM ir_asset ia LEFT JOIN ir_model_data imd ON imd.res_id = ia.id AND model
 = 'ir.asset' WHERE imd IS NULL
+-------+
| count |
|-------|
| 0     |
+-------+
```

With `test_assets2` being a freshly created 16.0 db with the following modules installed: `find . -path "**/static" -type d | cut -d"/" -f3,4,5 | sed 's+addons/++' | sed 's+/+ +g' | awk '/16.0/ {print $2}' | sed '/theme/d' | sed '/odoo/d' | sed '/test/d' | tr '\n' , | sed 's/,$//'`