### PR TITLE
[FIX] upgrade report: fix disabled/overwritten views links on saas~17.2

### DIFF
--- a/src/util/report-migration.xml
+++ b/src/util/report-migration.xml
@@ -9,7 +9,6 @@
           'Overridden views': ['The below standard views have been overriden with their original content during the migration because the changes made in them were no longer valid.', '%(xml_id)s'],
           'Disabled views': ['The below custom views have been disabled during the migration because they were no longer valid.', '%(name)s'],
         }"/>
-        <t t-set="view_action_link" t-value="'web?debug=1#view_type=form&amp;model=ir.ui.view&amp;action=%s&amp;id=%%s' % action_view_id"/>
         <t t-set="message_type" t-value="view_message_types[category]"/>
         <li><details t-if="messages[category]">
           <summary>
@@ -22,12 +21,12 @@
               <t t-if="view.get('copy_id')">
                 <t t-esc="message_type[1] % view"/>
                 &amp;nbsp;
-                <a t-att-href="view_action_link % view['id']" target="_blank">Original</a>
+                <t t-raw="get_anchor_link_to_record('ir.ui.view', view['id'], 'Original', action_id=action_view_id)"/>
                 &amp;nbsp;
-                <a t-att-href="view_action_link % view['copy_id']" target="_blank">Copy</a>
+                <t t-raw="get_anchor_link_to_record('ir.ui.view', view['copy_id'], 'Copy', action_id=action_view_id)"/>
               </t>
               <t t-if="not view.get('copy_id')">
-                  <a t-att-href="view_action_link % view['id']" target="_blank"><t t-esc="message_type[1] % view"/></a>
+                  <t t-raw="get_anchor_link_to_record('ir.ui.view', view['id'], message_type[1] % view, action_id=action_view_id)"/>
               </t>
             </li>
           </t>
@@ -39,7 +38,7 @@
           <summary>During the upgrade some fields have been removed. The records below have been automatically corrected.</summary>
           <ul>
             <t t-foreach="messages[category]" t-as="message">
-              <li><a t-att-href="'web?debug=1#view_type=form&amp;model=%s&amp;id=%s' % (message[0][0], message[0][1])" t-esc="message[0][2]" target="_blank"/></li>
+              <t t-raw="get_anchor_link_to_record(*message[0])"/>
             </t>
           </ul>
         </details></li>

--- a/src/util/report.py
+++ b/src/util/report.py
@@ -94,6 +94,7 @@ def announce_migration_report(cr):
         "action_view_id": e.ref("base.action_ui_view").id,
         "major_version": release.major_version,
         "messages": migration_reports,
+        "get_anchor_link_to_record": get_anchor_link_to_record,
     }
     _logger.info(migration_reports)
     render = e["ir.qweb"].render if hasattr(e["ir.qweb"], "render") else e["ir.qweb"]._render
@@ -230,7 +231,7 @@ def announce(
 
 def get_anchor_link_to_record(model, id, name, action_id=None):
     _validate_model(model)
-    return '<a target="_blank" href="web?debug=1#view_type=form&amp;model=%s&amp;action=%s&amp;id=%s">%s</a>' % (
+    return '<a target="_blank" href="/web?debug=1#view_type=form&amp;model=%s&amp;action=%s&amp;id=%s">%s</a>' % (
         model,
         action_id or "",
         id,


### PR DESCRIPTION
With path-based routing added to saas~17.2 we need to force the root relative url as the discuss channel url will not be `/web` anymore, but `/odoo/discuss.channel_*/discuss'.