### PR TITLE
[FIX] util/report-migration: avoid invalid opcode in 10.0

### DIFF
--- a/src/util/report-migration.xml
+++ b/src/util/report-migration.xml
@@ -38,7 +38,7 @@
           <summary>During the upgrade some fields have been removed. The records below have been automatically corrected.</summary>
           <ul>
             <t t-foreach="messages[category]" t-as="message">
-              <t t-raw="get_anchor_link_to_record(*message[0])"/>
+              <t t-raw="get_anchor_link_to_record(message[0][0], message[0][1], message[0][2])"/>
             </t>
           </ul>
         </details></li>


### PR DESCRIPTION
The unpacking call use the CALL_FUNCTION_VAR opcode, but it has only been supported with the Python3 support[^1].

```
❯ echo 'get_anchor_link_to_record(*message[0])' | python2 -m dis
  1           0 LOAD_NAME                0 (get_anchor_link_to_record)
              3 LOAD_NAME                1 (message)
              6 LOAD_CONST               0 (0)
              9 BINARY_SUBSCR
             10 CALL_FUNCTION_VAR        0
             13 POP_TOP
             14 LOAD_CONST               1 (None)
             17 RETURN_VALUE
```

See: efc5663171421755c94cc469f6db6414d5fd3b80
Closes: https://github.com/odoo/upgrade-util/issues/61

[^1]: https://github.com/odoo/odoo/commit/6e9d29df1d6335d41a950633478551c78484a794#diff-4af16af8fba18ea46e1f800bba43e1736b41e805d645656a0915cb05e5f5cc0fR97-R98