### PR TITLE
[FIX] util/pg: always change type with USING for booleans

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -570,9 +570,12 @@ def alter_column_type(cr, table, column, type, using=None, logger=_logger):
     cr.execute(format_query(cr, "ALTER TABLE {} ADD COLUMN {} {}", table, column, sql.SQL(type)))
 
     using = sql.SQL(format_query(cr, using, tmp_column))
+    where_clause = sql.SQL("")
+    if column_type(cr, table, column) != "bool":
+        where_clause = sql.SQL(format_query(cr, "WHERE {} IS NOT NULL", tmp_column))
     explode_execute(
         cr,
-        format_query(cr, "UPDATE {} SET {} = {} WHERE {} IS NOT NULL", table, column, using, tmp_column),
+        format_query(cr, "UPDATE {} SET {} = {} {}", table, column, using, where_clause),
         table=table,
         logger=logger,
     )


### PR DESCRIPTION
For the ORM a NULL value in a boolean colum means False. We cannot exclude those values from the type conversion otherwise the assigned value may be wrong.

For example, in this usage:
```py
util.alter_column_type(cr, "table", "col", "varchar", using="CASE WHEN {0} THEN 'x' ELSE 'y' END"
```
we would fail to assign `x`/`y` to the column in null values.