### PR TITLE
[IMP] fix docstring syntax

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -1,6 +1,7 @@
 """
-This file contains tools for making views compatible with Odoo 17. Two main changes are
-performed here:
+This file contains tools for making views compatible with Odoo 17.
+
+Two main changes are performed here:
 1. Convert `attrs` attributes of view elements from domains into Python expressions.
 2. Remove `states` attribute, merge its logic into `invisible` attribute.
 
@@ -43,7 +44,9 @@ from odoo.upgrade import util
 
 def adapt_view(cr, view_xmlid):
     """
-    Example usage of the utilities in this script.
+    Adapt one view.
+
+    Example usage of the utilities in this file.
 
     We use `util.edit_view` because it handles the propagation of the changes to all
     languages while updating the whole arch. Alternatively you could just update specific
@@ -55,7 +58,6 @@ def adapt_view(cr, view_xmlid):
     IrUiView = util.env(cr)["ir.ui.view"].with_context(lang=lang)
     ```
     """
-
     vid = util.ref(view_xmlid)
     IrUiView = util.env(cr)["ir.ui.view"]
     view = IrUiView.browse(vid)
@@ -90,9 +92,7 @@ class InvalidDomainError(Exception):
 
 
 class Ast2StrVisitor(ast._Unparser):
-    """
-    Extend standard unparser to allow specific names to be replaced.
-    """
+    """Extend standard unparser to allow specific names to be replaced."""
 
     def __init__(self, replace_names=None):
         self._replace_names = replace_names if replace_names else DEFAULT_CONTEXT_REPLACE
@@ -104,7 +104,9 @@ class Ast2StrVisitor(ast._Unparser):
 
 def mod2bool_str(s):
     """
-    Convert yes/no/true/false/on/off into True/False strings. Otherwise returns the input unchanged.
+    Convert yes/no/true/false/on/off into True/False strings.
+
+    Otherwise returns the input unchanged.
     The checked values would raise an error instead if used in a Python expression.
     Note that 0 and 1 are left unchanged since they have the same True/False meaning in Python.
     """
@@ -117,7 +119,7 @@ def mod2bool_str(s):
 
 
 def _clean_bool(s):
-    """Minimal simplification of trivial boolean expressions"""
+    """Minimal simplification of trivial boolean expressions."""
     return {
         "(1)": "1",
         "(0)": "0",
@@ -130,7 +132,9 @@ def _clean_bool(s):
 
 def target_elem_and_view_type(elem, comb_arch):
     """
-    Find the target of an element. If there is no `comb_arch` or the element doesn't look like
+    Find the target of an element.
+
+    If there is no `comb_arch` or the element doesn't look like
     targeting anything (no position attributes) assume the input `elem` is the target and return it.
     Along with the target we also return the view type of the elem, plus the field path from the
     arch root.
@@ -400,7 +404,8 @@ def fix_attrs(cr, model, arch, comb_arch):
 
 def check_true_false(lv, ov, rv_ast):
     """
-    Returns True/False if the leaf (lp, op, rp) is something that can be considered as a True/False leaf.
+    Return True/False if the leaf (lp, op, rp) is something that can be considered as a True/False leaf.
+
     Otherwise returns None.
     """
     ov = {"=": "==", "<>": "!="}.get(ov, ov)
@@ -432,7 +437,9 @@ def ast_term2domain_term(term):
 
 def convert_attrs_val(cr, model, field_path, val):
     """
-    Convert an `attrs` value into a python formula. We need to use the AST representation because
+    Convert an `attrs` value into a python formula.
+
+    We need to use the AST representation because
     values representing domains could be:
     * an if, or boolean, expression returning alternative domains
     * a string constant with the domain
@@ -516,6 +523,7 @@ def target_field_type(cr, model, path):
 def convert_domain_leaf(cr, model, field_path, leaf):
     """
     Convert a domain leaf (tuple) into a python expression.
+
     It always return the expression surrounded by parenthesis such that it's safe to use it as a sub-expression.
     """
     if isinstance(leaf, bool):

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -75,8 +75,7 @@ def version_between(a, b):
     See also :func:`~odoo.upgrade.util.misc.version_gte`
 
     .. note::
-
-        Bounds are inclusive.
+       The bounds are inclusive.
 
     :param str a: Odoo version, lower bound
     :param str b: Odoo version, upper bound

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -308,7 +308,7 @@ def explode_execute(cr, query, table, alias=None, bucket_size=10000, logger=_log
     :return: the sum of `cr.rowcount` for each query run
     :rtype: int
 
-    .. warning:
+    .. warning::
        It's up to the caller to ensure the queries do not update the same records in
        different buckets. It is advised to never use this function for `DELETE` queries on
        tables with self references due to the potential `ON DELETE` effects.

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -314,7 +314,7 @@ def remove_record(cr, name):
     """
     Remove a record and its references corresponding to the given :term:`xml_id <external identifier>`.
 
-    :param str name: record xml_id, under the format `module`.`name`
+    :param str name: record xml_id, under the format `module.name`
     """
     if isinstance(name, basestring):
         if "." not in name:
@@ -630,8 +630,8 @@ def rename_xmlid(cr, old, new, noupdate=None, on_collision="fail"):
     .. note::
        This function does not remove records, it only updates xml_ids.
 
-    :param str old: current xml_id of the record, under the format `module`.`name`
-    :param str new: new xml_id of the record, under the format `module`.`name`
+    :param str old: current xml_id of the record, under the format `module.name`
+    :param str new: new xml_id of the record, under the format `module.name`
     :param bool or None noupdate: value to set on the `noupdate` flag of the xml_id,
                                   ignored if `None`
     :param str on_collision: how to proceed if the xml_id already exists, the options are
@@ -707,7 +707,7 @@ def ref(cr, xmlid):
     """
     Return the id corresponding to the given :term:`xml_id <external identifier>`.
 
-    :param str xml_id: record xml_id, under the format `module`.`name`
+    :param str xml_id: record xml_id, under the format `module.name`
     :return: ID of the referenced record, `None` if not found.
     :rtype: int or `None`
     """
@@ -734,7 +734,7 @@ def force_noupdate(cr, xmlid, noupdate=True, warn=False):
     """
     Update the `noupdate` flag of a record.
 
-    :param str xmlid: record xml_id, under the format `module`.`name`
+    :param str xmlid: record xml_id, under the format `module.name`
     :param bool noupdate: value to set on the `noupdate` flag
     :param warn: whether to output a warning in the logs when the flag was switched from
                  `True` to `False`
@@ -769,10 +769,11 @@ def ensure_xmlid_match_record(cr, xmlid, model, values):
     found record. When no matching record is found, nothing is done. In all cases the
     referenced record, after a possible update, of the xml_id is returned.
 
-    :param str xmlid: record xml_id, under the format `module`.`name`
+    :param str xmlid: record xml_id, under the format `module.name`
     :param str model: model name of the record
     :param dict values: mapping of field names to values the record must fulfill
-                        .. example:
+
+                        .. example::
 
                            .. code-block:: python
 
@@ -782,7 +783,7 @@ def ensure_xmlid_match_record(cr, xmlid, model, values):
     :return: the ID of the matched record, `None` if no record found
     :rtype: int or None
 
-    .. tip:
+    .. tip::
        This function is useful when migrating in-database records into a custom module, to
        create the xml_ids before the module is updated and avoid duplication.
     """
@@ -872,7 +873,7 @@ def update_record_from_xml(
 
     Optionally this function can reset the translations of some fields.
 
-    :param str xmlid: record xml_id, under the format `module`.`name`
+    :param str xmlid: record xml_id, under the format `module.name`
     :param bool reset_write_metadata: whether to update the `write_date` of the record
     :param bool force_create: whether the record is created if it does not exist
     :param str from_module: name of the module from which to update the record, necessary
@@ -882,12 +883,12 @@ def update_record_from_xml(
     :param bool ensure_references: whether referred records via `ref` XML attributes
                                    should also be updated.
 
-    .. warning:
+    .. warning::
        This functions uses the ORM, therefore it can only be used after **all** models
        referenced in the data specs of the record are already **loaded**. In practice this
        means that this function should be used in `post-` or `end-` scripts.
 
-    .. note:
+    .. note::
        The standard behavior of ORM is to create the record if it doesn't exist, including
        its xml_id. That will happen on this function as well.
     """


### PR DESCRIPTION
Some {warning,tip,example} blocks were not being rendered.