### PR TITLE
[FIX] util/domains: add domain field

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -150,6 +150,8 @@ def _get_domain_fields(cr):
         DomainField("documents_share", "domain", documents_domains_target),
         DomainField("documents_workflow_rule", "domain", documents_domains_target),
         DomainField("loyalty_rule", "rule_domain", "'product.product'"),
+        DomainField("loyalty_rule", "product_domain", "'product.product'"),
+        DomainField("loyalty_reward", "discount_product_domain", "'product.product'"),
     ]
 
     for df in result:


### PR DESCRIPTION
Since saas~15.3 we have:
* `loyalty.rule` with  `product_domain`
* `loyalty.reward` with `discount_product_domain`

See odoo/odoo@9bb9eaf06726ec6a97c377c1cc2dfa550c1f2be7