### PR TITLE
[FIX] util/pg: use the old column to check the type

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -571,7 +571,7 @@ def alter_column_type(cr, table, column, type, using=None, logger=_logger):
 
     using = sql.SQL(format_query(cr, using, tmp_column))
     where_clause = sql.SQL("")
-    if column_type(cr, table, column) != "bool":
+    if column_type(cr, table, tmp_column) != "bool":
         where_clause = sql.SQL(format_query(cr, "WHERE {} IS NOT NULL", tmp_column))
     explode_execute(
         cr,


### PR DESCRIPTION
It's the original column what we need to check, the target column would
have a different type.

See 353c206a3303ccecf9ebedc5c51dd3381bb74ef6
