### PR TITLE
[FIX] base/saas~17.0: do not adapt invalid domains

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -491,7 +491,10 @@ def convert_attrs_val(cr, model, field_path, val):
                 op = {"&": "and", "|": "or"}[item]
                 stack.append(f"({left} {op} {right})")
             else:
-                stack.append(convert_domain_leaf(cr, model, field_path, item))
+                try:
+                    stack.append(convert_domain_leaf(cr, model, field_path, item))
+                except Exception:
+                    raise InvalidDomainError(ast.unparse(orig_ast)) from None
         assert len(stack) == 1
         res = stack.pop()
         assert res[0] == "(" and res[-1] == ")", res


### PR DESCRIPTION
Pretty much a copy of https://github.com/odoo/upgrade/pull/5916 since this file was moved to `upgrade-util` since then.

We handle the most common cases and as a last resort we call `convert_domain_leaf()` in order to convert a domain to a valid Python expression. If that fails, we may confidently state that the given domain is invalid, thus we skip its adaptation altogether.