### PR TITLE
[FIX] tests/test_util: mute logger in tests

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -579,9 +579,10 @@ class TestPG(UnitTestCase):
 
         threading.current_thread().testing = False
         # exploded queries will generate a SerializationFailed error, causing some of the queries to be retried
-        util.explode_execute(
-            cr, util.format_query(cr, "DELETE FROM {}", TEST_TABLE_NAME), TEST_TABLE_NAME, bucket_size=1
-        )
+        with mute_logger(util.pg._logger.name, "odoo.sql_db"):
+            util.explode_execute(
+                cr, util.format_query(cr, "DELETE FROM {}", TEST_TABLE_NAME), TEST_TABLE_NAME, bucket_size=1
+            )
         threading.current_thread().testing = True
 
         if hasattr(self, "_savepoint_id"):


### PR DESCRIPTION
To avoid noise in CI runs.