### PR TITLE
[FIX] base/17.0: skip empty attrs

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -216,7 +216,7 @@ def fix_elem(cr, model, elem, comb_arch):
                 etree.tostring(telem).decode(),
             )
 
-    if "attrs" in elem.attrib:
+    if elem.get("attrs"):
         attrs_val = elem.get("attrs")
         ast_attrs = ast_parse(attrs_val)
         if isinstance(ast_attrs, ast.Dict):
@@ -232,7 +232,7 @@ def fix_elem(cr, model, elem, comb_arch):
                 attrs_val,
                 etree.tostring(elem).decode(),
             )
-        elem.attrib.pop("attrs")
+    elem.attrib.pop("attrs", "")
 
     for mod in MODS:
         if mod not in elem.attrib and mod not in attrs:


### PR DESCRIPTION
Avoid error if `attrs` is already empty.

```
  File "/tmp/tmpxxqc0zp2/migrations/base/17.0.1.3/attr_domains2expr.py", line 221, in fix_elem
    ast_attrs = ast_parse(attrs_val)
  File "/tmp/tmpxxqc0zp2/migrations/base/17.0.1.3/attr_domains2expr.py", line 333, in ast_parse
    return ast.parse(val.strip(), mode="eval").body
  File "/usr/lib/python3.10/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 0

SyntaxError: invalid syntax
```

```
(Pdb) tostring(elem)
b'<field name="origin" attrs=""/>\n              '
```
