### PR TITLE
[FIX] attr_domains2expr: missing parameter and tracestack if view doesn't have inherit_id

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -58,14 +58,14 @@ def adapt_view(cr, view_xmlid):
     IrUiView = util.env(cr)["ir.ui.view"].with_context(lang=lang)
     ```
     """
-    vid = util.ref(view_xmlid)
+    vid = util.ref(cr, view_xmlid)
     IrUiView = util.env(cr)["ir.ui.view"]
     view = IrUiView.browse(vid)
 
     # disable view to avoid it being applied to the parent arch
     view.active = False
     # get combined arch of the parent view
-    comb_arch = view.inherit_id._get_combined_arch()
+    comb_arch = view.inherit_id._get_combined_arch() if view.inherit_id else None
 
     # update current view arch
     new_arch = etree.fromstring(view.arch_db)


### PR DESCRIPTION
-This commit add missing 'cr' parameter to util.ref method and fix when getting combined arch for inherit view it might get stace track if that view doesn't have inherit_id, check at
https://github.com/odoo/odoo/blob/86fb725c03171b84287812d0a9d1e00c86044acd/odoo/addons/base/models/ir_ui_view.py#L628