### PR TITLE
[FIX]util/models: improve query for custom fields

### DIFF
--- a/src/util/models.py
+++ b/src/util/models.py
@@ -512,12 +512,10 @@ def remove_inherit_from_model(cr, model, inherit, keep=(), skip_inherit=()):
         [tuple(inherit_models), list(keep)],
     )
     for field, ftype, relation, store in cr.fetchall():
-        if ftype.endswith("2many") and store:
-            # for mixin, x2many are filtered by their model.
-            # for "classic" inheritance, the caller is responsible to drop the underlying m2m table
-            # (or keeping the field)
+        if ftype == "one2many" and store:
+            # for mixin, one2many are filtered by their model and res_id.
             table = table_of_model(cr, relation)
-            irs = [ir for ir in indirect_references(cr) if ir.table == table]
+            irs = [ir for ir in indirect_references(cr) if ir.table == table and ir.res_id is not None]
             for ir in irs:
                 query = 'DELETE FROM "{}" WHERE ({})'.format(ir.table, ir.model_filter())
                 cr.execute(query, [model])  # cannot be executed in parallel. See git blame.


### PR DESCRIPTION
When utilizing 'def remove_inherit_from_model' method, it removes fields to disconnect two models,
eliminating all custom fields created by customers. To prevent this, adding one condition.

Recentally i saw that issue [here](https://github.com/odoo/upgrade/blob/5ace23070c0c628f3db1ed2c0179a020003ec8d3/migrations/base_automation/saas~16.5.1.0/pre-migrate.py#L84)
Here he tries to remove the connection between base.automation and ir.act.server. If customers have created custom fields using the studio in the base.automation model, this method will remove all custom fields during migration.