### PR TITLE
[IMP] util/domains.py: handle `any` operator introduced in Odoo 17

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -258,6 +258,21 @@ class TestAdaptOneDomain(UnitTestCase):
         else:
             self.assertIsNone(new_domain)
 
+    @unittest.skipUnless(util.version_gte("17.0"), "`any` operator only supported from Odoo 17")
+    def test_any_operator(self):
+        domain = [("partner_id", "any", [("complete_name", "=", "Odoo")])]
+        expected = [("partner_id", "any", [("full_name", "=", "Odoo")])]
+
+        new_domain = _adapt_one_domain(self.cr, "res.partner", "complete_name", "full_name", "res.company", domain)
+        self.assertEqual(new_domain, expected)
+
+        # test it also works recursively
+        domain = [("partner_id", "any", [("title", "not any", [("shortcut", "like", "S.A.")])])]
+        expected = [("partner_id", "any", [("title", "not any", [("abbr", "like", "S.A.")])])]
+
+        new_domain = _adapt_one_domain(self.cr, "res.partner.title", "shortcut", "abbr", "res.company", domain)
+        self.assertEqual(new_domain, expected)
+
 
 class TestAdaptDomainView(UnitTestCase):
     def test_adapt_domain_view(self):

--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -226,7 +226,22 @@ def _adapt_one_domain(cr, target_model, old, new, model, domain, adapter=None, f
     def clean_term(term):
         if isinstance(term, basestring) or not isinstance(term[0], basestring):
             return term
-        return (clean_path(term[0]), term[1], term[2])
+        left, op, right = term
+        left = clean_path(left)
+        if op in ("any", "not any"):
+            new_right = _adapt_one_domain(
+                cr,
+                target_model,
+                old,
+                new,
+                model=_model_of_path(cr, model, left.split(".")),
+                domain=right,
+                adapter=adapter,
+                force_adapt=force_adapt,
+            )
+            if new_right is not None:
+                right = new_right
+        return (left, op, right)
 
     final_dom = []
     changed = False


### PR DESCRIPTION
In such domain, the right-hand term is domain that should also be adatped.

See https://github.com/odoo/odoo/commit/5a998694a6f353da05d7f69e4c59b9e7dd139e27