### PR TITLE
[IMP] specific: check if model exists

### DIFF
--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -63,8 +63,12 @@ def rename_custom_model(cr, model_name, new_model_name, custom_module=None, repo
 
 
 def rename_custom_module(cr, old_module_name, new_module_name, report_details=""):
-    rename_module(cr, old_module_name, new_module_name)
+    cr.execute("SELECT 1 FROM ir_module_module WHERE name = %s", [old_module_name])
+    if not cr.rowcount:
+        _logger.warning("Module %r not found: skip renaming", old_module_name)
+        return
 
+    rename_module(cr, old_module_name, new_module_name)
     add_to_migration_reports(
         category="Custom modules",
         message="The custom module '{old_module_name}' was renamed to '{new_module_name}'. {report_details}".format(

--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -5,7 +5,7 @@ from .helpers import _validate_table
 from .misc import _cached
 from .models import rename_model
 from .modules import rename_module
-from .pg import column_exists, rename_table
+from .pg import column_exists, rename_table, table_exists
 from .report import add_to_migration_reports
 
 _logger = logging.getLogger(__name__)
@@ -84,6 +84,10 @@ def rename_custom_table(
     custom_module=None,
     report_details="",
 ):
+    if not table_exists(cr, table_name):
+        _logger.warning("Table %r not found: skip renaming", table_name)
+        return
+
     rename_table(cr, table_name, new_table_name, remove_constraints=False)
 
     module_details = " from module '{}'".format(custom_module) if custom_module else ""

--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -47,6 +47,11 @@ def dispatch_by_dbuuid(cr, version, callbacks):
 
 
 def rename_custom_model(cr, model_name, new_model_name, custom_module=None, report_details=""):
+    cr.execute("SELECT 1 FROM ir_model WHERE model = %s", [model_name])
+    if not cr.rowcount:
+        _logger.warning("Model %r not found: skip renaming", model_name)
+        return
+
     rename_model(cr, model_name, new_model_name, rename_table=True)
     module_details = " from module '{}'".format(custom_module) if custom_module else ""
     add_to_migration_reports(

--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -102,6 +102,7 @@ def rename_custom_table(
 def rename_custom_column(cr, table_name, col_name, new_col_name, custom_module=None, report_details=""):
     _validate_table(table_name)
     if not column_exists(cr, table_name, col_name):
+        _logger.warning("Column %r not found on table %r: skip renaming", col_name, table_name)
         return
     cr.execute('ALTER TABLE "{}" RENAME COLUMN "{}" TO "{}"'.format(table_name, col_name, new_col_name))
     module_details = " from module '{}'".format(custom_module) if custom_module else ""


### PR DESCRIPTION
When a custom model conflicts with a standard one we may choose to write a specific fix, using the `rename_custom_model` util to rename it.

However, although unlikely, customers may remove that model in successive upgrade requests, making the call to `rename_model` unnecessary and the extra entry in the migration report unnecessary.