### PR TITLE
[IMP] base version: lower from warning to info

### DIFF
--- a/src/util/inherit.py
+++ b/src/util/inherit.py
@@ -3,7 +3,7 @@ import logging
 import operator
 import os
 
-from .const import ENVIRON
+from .const import ENVIRON, NEARLYWARN
 from .misc import _cached, parse_version, version_gte
 
 _logger = logging.getLogger(__name__)
@@ -63,7 +63,8 @@ def _get_base_version(cr):
         state, version = cr.fetchone()
         if state != "to upgrade":
             major = ".".join(version.split(".")[:2])
-            _logger.warning(
+            _logger.log(
+                NEARLYWARN,
                 "Assuming upgrading from Odoo %s. If it's not the case, specify the environment variable `ODOO_BASE_VERSION`.",
                 major,
             )


### PR DESCRIPTION
In Odoofin, we don't have a master branch, we always update current stable version (17.0 at the moment) through module migration scripts. This was previously handled by internal at each major version update. We now handle the scripts in the accounting team, thus have an upgrade CI.

The warning modified in this PR seems to be legitimally raised, since base is not changed, it is probably skipped in the update even if we do the upgrade with `-u all`. The warning level is preventing us to merge without admin rights, thus we propose to lower the warning to info level.

Example of build with this warning: https://runbot.odoo.com/runbot/build/63601210