### PR TITLE
[FIX]: allow migrating tables without primary index

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -1048,9 +1048,12 @@ def rename_table(cr, old_table, new_table, remove_constraints=True):
         """,
         [new_table],
     )
-    (old_pkey,) = cr.fetchone()
-    new_pkey = new_table + "_pkey"
-    cr.execute(sql.SQL("ALTER INDEX {} RENAME TO {}").format(sql.Identifier(old_pkey), sql.Identifier(new_pkey)))
+    if cr.rowcount:
+        (old_pkey,) = cr.fetchone()
+        new_pkey = new_table + "_pkey"
+        cr.execute(sql.SQL("ALTER INDEX {} RENAME TO {}").format(sql.Identifier(old_pkey), sql.Identifier(new_pkey)))
+    else:
+        new_pkey = ""  # no PK renamed
 
     # rename indexes (except the pkey's one and those not containing $old_table)
     cr.execute(


### PR DESCRIPTION
During a migration from v12 to v13, this fixes this error:

```
2024-06-12 12:28:54,522 825 CRITICAL db_1732812 odoo.service.server: Failed to initialize database `db_1732812`.
Traceback (most recent call last):
  File "/home/odoo/src/odoo/13.0/odoo/service/server.py", line 1194, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/13.0/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/13.0/odoo/modules/loading.py", line 424, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check)
  File "/home/odoo/src/odoo/13.0/odoo/modules/loading.py", line 315, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/home/odoo/src/odoo/13.0/odoo/modules/loading.py", line 177, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/home/odoo/src/odoo/13.0/odoo/modules/migration.py", line 186, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmprdd50vnu/migrations/mass_mailing/saas~12.5.2.0/pre-10-models.py", line 21, in migrate
    util.rename_model(cr, "mail.mass_mailing.list_contact_rel", "mailing.contact.subscription")
  File "/tmp/tmprdd50vnu/migrations/util/models.py", line 236, in rename_model
    table_of_model(cr, new),
  File "/tmp/tmprdd50vnu/migrations/util/pg.py", line 1051, in rename_table
    (old_pkey,) = cr.fetchone()
TypeError: 'NoneType' object is not iterable
```

@moduon @emiliopascual MT-6161