### PR TITLE
[IMP] util/orm: do not tweak res.users.lang cache validation

### DIFF
--- a/src/util/orm.py
+++ b/src/util/orm.py
@@ -222,6 +222,8 @@ def no_selection_cache_validation(f=None):
     old_convert = ofields.Selection.convert_to_cache
 
     def _convert(self, value, record, validate=True):
+        if self.model_name == "res.users" and self.name == "lang":
+            return old_convert(self, value, record, validate=validate)
         return old_convert(self, value, record, validate=False)
 
     if f is None:


### PR DESCRIPTION
`res.users.lang` is a widely used field in the ORM that it's better to not mess with for performance reasons. If a DB has invalid codes the ORM would deal with them graciously.