### PR TITLE
[IMP] specific: reset cowed views if website installed

### DIFF
--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -4,7 +4,7 @@ import logging
 from .helpers import _validate_table
 from .misc import _cached
 from .models import rename_model
-from .modules import rename_module
+from .modules import module_installed, rename_module
 from .pg import column_exists, rename_table, table_exists
 from .report import add_to_migration_reports
 
@@ -114,6 +114,9 @@ def rename_custom_column(cr, table_name, col_name, new_col_name, custom_module=N
 
 
 def reset_cowed_views(cr, xmlid, key=None):
+    if not module_installed(cr, "website"):
+        # Cowed views can only exist in multi-website environments
+        return None
     if "." not in xmlid:
         raise ValueError("Please use fully qualified name <module>.<name>")
 


### PR DESCRIPTION
Cowed views can only exist if module 'website' is installed.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/17.0/odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/17.0/odoo/modules/loading.py", line 514, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/17.0/odoo/modules/migration.py", line 240, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmp0gtsfuy9/migrations/sale/17.0.1.2/end-~update_views.py", line 5, in migrate
    util.reset_cowed_views(cr, "sale.sale_order_portal_template")
  File "/tmp/tmp0gtsfuy9/migrations/util/specific.py", line 123, in reset_cowed_views
    cr.execute(
  File "/home/odoo/src/odoo/17.0/odoo/sql_db.py", line 332, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UndefinedColumn: column u.website_id does not exist
LINE 11:            AND u.website_id IS NOT NULL
```