### PR TITLE
[FIX] tests/test_util: filters in `sort` must be a JSON array

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -394,7 +394,7 @@ class TestRemoveFieldDomains(UnitTestCase):
         cr = self.env.cr
         cr.execute(
             "INSERT INTO ir_filters(name, model_id, domain, context, sort)"
-            "     VALUES ('test', 'base.module.update', %s, '{}', 'id') RETURNING id",
+            "     VALUES ('test', 'base.module.update', %s, '{}', '[]') RETURNING id",
             [str(domain)],
         )
         (filter_id,) = cr.fetchone()


### PR DESCRIPTION
Since odoo/odoo@5b95abb8 we enforce `sort` column to be a stringified
JSON array of field names.
