### PR TITLE
[FIX] attr_domains2expr: Remove redundant xpaths

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -396,6 +396,8 @@ def fix_attrs(cr, model, arch, comb_arch):
             new_elem = etree.Element("attribute", name=mod)
             new_elem.text = fake_elem.get(mod)
             parent.append(new_elem)
+        if len(parent) == 0 and parent.getparent() is not None:
+            parent.getparent().remove(parent)
 
     return success
 


### PR DESCRIPTION
if empty attrs is present which useless itself like this

**org**
```
<xpath expr='..' position='attributes'>
	<attribute name='attrs'/>
</xpath>
```

**before fix**
```
<xpath expr='..' position='attributes'>
</xpath>
```
![image](https://github.com/user-attachments/assets/c368c3fb-51a9-442f-bf41-527edcf46b17)


this is just snippet of view their can be more customization.Yes it is customization issue but if we are removing attrs empty node. So, this can be handled by removing that xpath also .So at least studio view or any view won't disable due to this while validating view ``check_xml``. 

**traceback**
```
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 2443, in <dictcomp>
    v_type: self.get_view(
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 2628, in get_view
    result = dict(self._get_view_cache(view_id, view_type, **options))
  File "<decorator-gen-51>", line 2, in _get_view_cache
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/cache.py", line 104, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 2584, in _get_view_cache
    arch, view = self._get_view(view_id, view_type, **options)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 2531, in _get_view
    arch = view._get_combined_arch()
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 950, in _get_combined_arch
    arch = root.with_prefetch(tree_views._prefetch_ids)._combine(hierarchy)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 891, in _combine
    combined_arch = view.apply_inheritance_specs(combined_arch, arch)
  File "/home/odoo/odoo/enterprise/17.0/web_studio/models/ir_ui_view.py", line 603, in apply_inheritance_specs
    return self._apply_studio_specs(source, specs_tree)
  File "/home/odoo/odoo/enterprise/17.0/web_studio/models/ir_ui_view.py", line 586, in _apply_studio_specs
    source = super(View, self).apply_inheritance_specs(source, spec)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 828, in apply_inheritance_specs
    self._raise_view_error(str(e), specs_tree)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_ui_view.py", line 705, in _raise_view_error
    raise err from from_exception
ValueError: Element '<xpath expr="//form[1]/sheet[1]/group[1]/group[2]/field[@name=&#39;tag_ids&#39;]">' cannot be located in parent view

```
**after fix** 
it will also remove because this redundant and does not make any sense present in view.