### PR TITLE
[FIX] snippets: properly unwrap during xml upgrade

### DIFF
--- a/src/util/snippets.py
+++ b/src/util/snippets.py
@@ -205,7 +205,7 @@ class HTMLConverter:
         )
         has_changed = self.has_changed(els)
         new_content = (
-            re.sub(r"(^<wrap>|</wrap>$)", "", etree.tostring(els, encoding="unicode").strip())
+            re.sub(r"(^<wrap>|</wrap>$|^<wrap/>$)", "", etree.tostring(els, encoding="unicode").strip())
             if has_changed
             else content
         )


### PR DESCRIPTION
We wrap the content to upgrade into a `<wrap>` element before upgrading it. After the upgrade, we unwrap the content using `re.sub`... but this did not consider the case where there is no content in the wrapper anymore. Indeed, in that case, the XML formatter sets the content to `<wrap/>` and not `<wrap></wrap>`.

Related to community https://github.com/odoo/odoo/pull/172755
Related to enterprise https://github.com/odoo/enterprise/pull/66488
Related to upgrade https://github.com/odoo/upgrade/pull/6254
Related to task-4008369