### PR TITLE
[FIX] util.indirect_references: add new, special case for ir_act_window

### DIFF
--- a/src/util/indirect_references.py
+++ b/src/util/indirect_references.py
@@ -29,6 +29,7 @@ def indirect_references(cr, bound_only=False):
         IR("ir_cron", "model", None, set_unknown=True),
         IR("ir_act_report_xml", "model", None, set_unknown=True),
         IR("ir_act_window", "res_model", "res_id"),
+        IR("ir_act_window", "res_model", None),
         IR("ir_act_window", "src_model", None),
         IR("ir_act_server", "wkf_model_name", None),
         IR("ir_act_server", "crud_model_name", None),


### PR DESCRIPTION
`ir_act_window` is a special case where it's possible to have `res_model` set and `res_id` NULL
at the same time, contrary to the usual where `res_id` points to the table of `res_model`,
thus it usually makes sense to have both set. Because of this we need two IR entries that will
cover both cases.
    
An example of this special case can be an action that was created automatically for a button
created through Studio. Steps to reproduce:

1. Create a database in 15.0 and install `web_studio` and `sale_subscription`.

2. Using Studio, create a button in form view of `res.partner` that as a related field takes any field from `sale.subscription`. Studio will automatically create an action for this button with `res_model = 'sale.subscription'` and `res_id = NULL`.

3. Upgrade to 16.0. When the merge of `sale.subscription` into `sale.order` happens, the action created for the button will be removed from `ir_act_window` because it's still referencing `sale.subscription` instead of `sale.order`. That in turn is caused by `replace_record_references_batch` not replacing references for `ir_act_window` records that don't have `res_id` set.