### PR TITLE
[IMP] util.remove_view : remove redundant t-calls

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1825,3 +1825,65 @@ class TestConvertFieldToHtml(UnitTestCase):
 
         self.assertEqual(default.json_value, '"<p>Test text</p>"')
         self.assertEqual(partner.x_testx, "<p>test partner field</p>")
+
+
+class TestRemoveView(UnitTestCase):
+    def test_remove_view(self):
+        test_view_1 = self.env["ir.ui.view"].create(
+            {
+                "name": "test_view_1",
+                "type": "qweb",
+                "key": "base.test_view_1",
+                "arch": """
+                <t t-name="base.test_view_1">
+                    <div>Test View 1 Content</div>
+                </t>
+                """,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {"name": "test_view_1", "module": "base", "model": "ir.ui.view", "res_id": test_view_1.id}
+        )
+        test_view_2 = self.env["ir.ui.view"].create(
+            {
+                "name": "test_view_2",
+                "type": "qweb",
+                "key": "base.test_view_2",
+                "arch": """
+                <t t-name="base.test_view_2">
+                    <t t-call="base.test_view_1"/>
+                    <div>Test View 2 Content</div>
+                </t>
+                """,
+            }
+        )
+        test_view_3 = self.env["ir.ui.view"].create(
+            {
+                "name": "test_view_3",
+                "type": "qweb",
+                "key": "base.test_view_3",
+                "arch": """
+                <t t-name="base.test_view_3">
+                    <t t-call="base.test_view_1"/>
+                    <t t-call="base.test_view_2"/>
+                </t>
+                """,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {"name": "test_view_3", "module": "base", "model": "ir.ui.view", "res_id": test_view_3.id}
+        )
+
+        # call by xml_id
+        util.remove_view(self.env.cr, xml_id="base.test_view_1")
+        util.invalidate(test_view_2)
+        util.invalidate(test_view_3)
+        self.assertFalse(test_view_1.exists())
+        self.assertNotIn('t-call="base.test_view_1"', test_view_2.arch_db)
+        self.assertNotIn('t-call="base.test_view_1"', test_view_3.arch_db)
+
+        # call by view_id
+        util.remove_view(self.env.cr, view_id=test_view_2.id)
+        util.invalidate(test_view_3)
+        self.assertFalse(test_view_2.exists())
+        self.assertNotIn('t-call="base.test_view_2"', test_view_3.arch_db)

--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1887,3 +1887,39 @@ class TestRemoveView(UnitTestCase):
         util.invalidate(test_view_3)
         self.assertFalse(test_view_2.exists())
         self.assertNotIn('t-call="base.test_view_2"', test_view_3.arch_db)
+
+
+class TestRenameXMLID(UnitTestCase):
+    def test_rename_xmlid(self):
+        test_view_1 = self.env["ir.ui.view"].create(
+            {
+                "name": "test_view_1",
+                "type": "qweb",
+                "key": "base.test_view_1",
+                "arch": """
+                <t t-name="base.test_view_1">
+                    <div>Test View 1 Content</div>
+                </t>
+                """,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {"name": "test_view_1", "module": "base", "model": "ir.ui.view", "res_id": test_view_1.id}
+        )
+        test_view_2 = self.env["ir.ui.view"].create(
+            {
+                "name": "test_view_2",
+                "type": "qweb",
+                "key": "base.test_view_2",
+                "arch": """
+                <t t-name="base.test_view_2">
+                    <t t-call="base.test_view_1"/>
+                    <div>Test View 2 Content</div>
+                </t>
+                """,
+            }
+        )
+        util.rename_xmlid(self.env.cr, "base.test_view_1", "base.rename_view")
+        util.invalidate(test_view_2)
+        self.assertIn('t-call="base.rename_view"', test_view_2.arch_db)
+        self.assertIn('t-name="base.rename_view"', test_view_1.arch_db)


### PR DESCRIPTION
While removing the view, removing the content having t-call in other views which  are calling to have the content of it.

As there are many specific fixes available for this [16776,15322,14413,13404,13325,12205,12335 etc..], it's better to handle  it in remove_view.

Before fix:
- t-call with the same xml_id will remain in other views that are using it. So during access of that view, the system is raising an error "view not found."

```
<t name="Payment" t-name="website_sale.payment">
    <t t-call="website_sale.cart_summary"/>
</t>
```

After fix:
- t-call will be removed, so no error will be raised.

```
<t name="Payment" t-name="website_sale.payment">
</t>
```

Traceback:
```
Error while render the template
ValueError: View 'website_sale.cart_summary' in website 1 not found
Template: website_sale.payment
Path: /t/t/div/div[1]/div/div[4]/div[1]/t
Node: <t t-call="website_sale.address_on_payment"/>
```