### PR TITLE
[FIX] util/domains: deprecation of ustr

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -25,11 +25,11 @@ except ImportError:
 
 try:
     from odoo.osv import expression
-    from odoo.tools import ustr
+    from odoo.tools import exception_to_unicode
     from odoo.tools.safe_eval import safe_eval
 except ImportError:
     from openerp.osv import expression
-    from openerp.tools import ustr
+    from openerp.tools import exception_to_unicode
     from openerp.tools.safe_eval import safe_eval
 
 from .const import NEARLYWARN
@@ -202,14 +202,14 @@ def _adapt_one_domain(cr, target_model, old, new, model, domain, adapter=None, f
         try:
             eval_dom = expression.normalize_domain(safe_eval(domain, evaluation_context, nocopy=True))
         except Exception as e:
-            oops = ustr(e)
+            oops = exception_to_unicode(e)
             _logger.log(NEARLYWARN, "Cannot evaluate %r domain: %r: %s", model, domain, oops)
             return None
     else:
         try:
             eval_dom = expression.normalize_domain(domain)
         except Exception as e:
-            oops = ustr(e)
+            oops = exception_to_unicode(e)
             _logger.log(NEARLYWARN, "Invalid %r domain: %r: %s", model, domain, oops)
             return None
 


### PR DESCRIPTION
Since it's only used to str-ify exceptions, this can just use the underlying `exception_to_unicode`, which [has existed][1] for longer than [`ustr` has used it][2]

Related to odoo/odoo#173811

[1]: https://github.com/odoo/odoo/commit/195fc4a475454ec8190b7d5480cdd97059621b5a
[2]: https://github.com/odoo/odoo/commit/8f81995ec84899292709608945287d8a3faf1b6d