### PR TITLE
[IMP] util/records: Fix edit_view docstring

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -185,8 +185,8 @@ def edit_view(cr, xmlid=None, view_id=None, skip_if_not_noupdate=True, active="a
 
     When the view is identified by `view_id`, the arch is always yielded if the view
     exists, with disregard to any `noupdate` flag it may have associated. When `xmlid` is
-    set, if the view `noupdate` flag is `True` then the arch will not be yielded *unless*
-    `skip_if_not_noupdate` is set to `False`. If `noupdate` is `False`, the view will be
+    set, if the view `noupdate` flag is `False` then the arch will not be yielded *unless*
+    `skip_if_not_noupdate` is set to `False`. If `noupdate` is `True`, the view will be
     yielded for edit.
 
     If the `active` argument is `True` or `False`, the `active` flag of the view will be set


### PR DESCRIPTION
[`edit_view`](https://github.com/odoo/upgrade-util/blob/c2cd2b7645d8d6a2f023f7a3ae2d75f8411ebea4/src/util/records.py#L169-L280) yields an xmlid view according to the following logic:
> If the view has `noupdate=False`, we assume that it is a standard view that'll be updated by the ORM later on, so by default we don't yield it when calling `edit_view`. We may force yield such a view when setting 'skip_if_not_noupdate` to False.

This behaviour was initially described correctly in the docstring, but the values of `noupdate` got mixed up in the new docstring in aaa1f0fee6870075e25cb5e6744e4c589bb32b46 .
This commit reverts the values in the docstring to the correct ones.