### PR TITLE
[FIX] base/17.0: skip invalid attrs

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -320,8 +320,13 @@ def fix_elem(cr, model, elem, comb_arch):
             )
         for key in extra:
             value = ast.unparse(attrs[key])
-            _logger.info("Inlined %s=%r", key, value)
-            elem.set(key, value)
+            try:
+                etree.QName(key)
+            except ValueError as e:
+                _logger.error("Skipping invalid attribute name %r in `attrs` with value: %s: %r", key, value, e)  # noqa: TRY400
+            else:
+                elem.set(key, value)
+                _logger.info("Inlined %s=%r", key, value)
 
     return success
 


### PR DESCRIPTION
Some of the extra attributes' keys that the customer might add to `attrs` are invalid for [lxml](https://github.com/lxml/lxml/blob/bce5b10da0e5d9e7c49b318dd168656d34ab95a1/src/lxml/apihelpers.pxi#L587) ([due to](https://github.com/lxml/lxml/blob/bce5b10da0e5d9e7c49b318dd168656d34ab95a1/src/lxml/includes/tree.pxd#L415) not being [valid](https://gitlab.gnome.org/GNOME/libxml2/-/blob/a530ff125dbf8ab4f297c0b91fc8fa34d4183bf5/valid.c?page=4#L3329-3351) for libxml). In these cases, those `attrs` elements cannot be inlined and are best skipped altogether.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/17.0/odoo/service/server.py", line 1302, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/17.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/17.0/odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/17.0/odoo/modules/loading.py", line 514, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/17.0/odoo/modules/migration.py", line 240, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmpqxlqi07y/migrations/base/saas~16.5.1.3/end-01-attrs-views.py", line 149, in migrate
    new_archs = fix_archs(info)
  File "/tmp/tmpqxlqi07y/migrations/base/saas~16.5.1.3/end-01-attrs-views.py", line 122, in fix_archs
    if not fix_attrs(cr, v.model, arch, comb_arch):
  File "/tmp/tmpqxlqi07y/migrations/base/17.0.1.3/attr_domains2expr.py", line 362, in fix_attrs
    success &= fix_elem(cr, model, elem, comb_arch)
  File "/tmp/tmpqxlqi07y/migrations/base/17.0.1.3/attr_domains2expr.py", line 326, in fix_elem
    elem.set(key, value)
  File "src/lxml/etree.pyx", line 831, in lxml.etree._Element.set
  File "src/lxml/apihelpers.pxi", line 585, in lxml.etree._setAttributeValue
  File "src/lxml/apihelpers.pxi", line 1763, in lxml.etree._attributeValidOrRaise
ValueError: Invalid attribute name '!required'
```