### PR TITLE
[FIX] util/fields: ensure path update for ir_exports_line

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -422,6 +422,7 @@ class TestIrExports(UnitTestCase):
                         (0, 0, {"name": "rate_ids/company_id/user_ids/name"}),
                         (0, 0, {"name": "rate_ids/company_id/user_ids/partner_id/user_ids/name"}),
                         (0, 0, {"name": "rate_ids/name"}),
+                        (0, 0, {"name": "rate_ids/company_id/user_ids/partner_id/user_ids/.id"}),
                     ],
                 }
             ]
@@ -437,6 +438,9 @@ class TestIrExports(UnitTestCase):
         self._invalidate()
         self.assertEqual(
             self.export.export_fields[2].name, "rate_ids/company_id/user_ids/partner_id/renamed_user_ids/name"
+        )
+        self.assertEqual(
+            self.export.export_fields[4].name, "rate_ids/company_id/user_ids/partner_id/renamed_user_ids/.id"
         )
 
         util.rename_field(self.cr, "res.users", "name", "new_name")

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -1088,6 +1088,10 @@ def _update_impex_renamed_fields_paths(cr, old_field_name, new_field_name, only_
             continue
         fixed_paths = {}
         for record_id, related_model, path in cr.fetchall():
+            has_id = path[-1] == ".id"
+            if has_id:
+                path = path[:-1]  # noqa: PLW2901
+
             new_path = [
                 new_field_name
                 if field.field_name == old_field_name and field.field_model in only_models
@@ -1095,6 +1099,8 @@ def _update_impex_renamed_fields_paths(cr, old_field_name, new_field_name, only_
                 for field in resolve_model_fields_path(cr, related_model, path)
             ]
             if len(new_path) == len(path) and new_path != path:
+                if has_id:
+                    new_path.append(".id")
                 fixed_paths[record_id] = "/".join(new_path)
         if fixed_paths:
             cr.execute(


### PR DESCRIPTION
**Issue:** When exporting data using the existing export template, a traceback error occurs.
```python
Traceback (most recent call last):
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 1783, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/17.0/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 1810, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 2014, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 759, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/17.0/addons/web/controllers/export.py", line 369, in namelist
    fields_data = self.fields_info(
  File "/home/odoo/src/odoo/17.0/addons/web/controllers/export.py", line 418, in fields_info
    fields[base]['relation'], base, fields[base]['string'],
KeyError: 'move_lines'
```
**Cause:** When a field is renamed, the path in `ir_exports_line` is not updated if it contains `.ids`. This happens because the resolve_model_fields_path fails to retrieve the field record from `ir_model_fields` where the field name is `.id` [here](https://github.com/odoo/upgrade-util/blob/b7fbb070807f8393a0b5dbac274e1651d32b309d/src/util/helpers.py#L284-L319) (because such field doesn't exists), which leads to [failing this condition](https://github.com/odoo/upgrade-util/blob/b7fbb070807f8393a0b5dbac274e1651d32b309d/src/util/fields.py#L1026) because of the difference in length of old and new path

> Some output from shell for better understanding [here](https://github.com/odoo/upgrade-util/blob/b7fbb070807f8393a0b5dbac274e1651d32b309d/src/util/fields.py#L1020-L1025) :
> 
> **Genereted new_path**
> ```python
> In [20]:             new_path = [
>     ...:                 new_field_name
>     ...:                 if field.field_name == old_field_name and field.field_model in only_models
>     ...:                 else field.field_name
>     ...:                 for field in resolve_model_fields_path(cr, 'stock.picking', ['move_lines','.id'])
>     ...:             ]
> 
> In [21]: new_path
> Out[21]: ['move_ids']
> 
> ```
> **Expected new_path**
> ```python
> In [22]:             new_path = [
>     ...:                 new_field_name
>     ...:                 if field.field_name == old_field_name and field.field_model in only_models
>     ...:                 else field.field_name
>     ...:                 for field in resolve_model_fields_path(cr, 'stock.picking', ['move_lines','id'])
>     ...:             ]
> 
> In [23]: new_path
> Out[23]: ['move_ids', 'id']
> ```
> 
> 

Original:
```sql
test_15.0=> select * from ir_exports_line ;
 id |                name                | export_id | create_uid |        create_date         | write_uid |         write_date         
----+------------------------------------+-----------+------------+----------------------------+-----------+----------------------------
 20 | move_lines/.id                     |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 21 | move_lines/show_details_visible    |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 22 | move_lines/company_id              |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 23 | move_lines/product_uom_category_id |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
(4 rows)
```

Before Fix:

```sql
test_15.0_17.0=> select * from ir_exports_line ;
 id |               name               | export_id | create_uid |        create_date         | write_uid |         write_date         
----+----------------------------------+-----------+------------+----------------------------+-----------+----------------------------
 20 | move_lines/.id                   |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 21 | move_ids/show_details_visible    |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 22 | move_ids/company_id              |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 23 | move_ids/product_uom_category_id |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
(4 rows)

```
After Fix:

```sql
test_15.0_17.0=> select * from ir_exports_line ;
 id |               name               | export_id | create_uid |        create_date         | write_uid |         write_date         
----+----------------------------------+-----------+------------+----------------------------+-----------+----------------------------
 20 | move_ids/.id                     |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 21 | move_ids/show_details_visible    |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 22 | move_ids/company_id              |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
 23 | move_ids/product_uom_category_id |         6 |          2 | 2024-09-06 09:25:01.707598 |         2 | 2024-09-06 09:25:01.707598
(4 rows)

```

- UPG: [1880309](https://upgrade.odoo.com/web#id=1880309&view_type=form&model=upgrade.request&cids=1)
- OPW: [4165981](https://www.odoo.com/odoo/project/70/tasks/4165981)