### PR TITLE
[FIX] util/orm: Disable only custom module record rule

### DIFF
--- a/src/util/orm.py
+++ b/src/util/orm.py
@@ -612,7 +612,7 @@ def custom_module_field_as_manual(env, rollback=True, do_flush=False):
         WITH custom_rules AS (
                 SELECT r.id
                   FROM ir_rule r
-             LEFT JOIN ir_model_data d ON d.model = 'ir.rule' AND d.res_id = r.id
+                  JOIN ir_model_data d ON d.model = 'ir.rule' AND d.res_id = r.id
                  WHERE COALESCE(d.module, '') NOT IN %s
                    AND r.active
                  )


### PR DESCRIPTION
db have record rule which are created from interface or either standard record rule external_id is missing got disable during neturlize(run_sanitizer) this  can block the upgrade process due to access error but actually with that  record rule  database is running fine but during upgrade after neutrlize upgrade process is blocked.So, better to disable only custom module record rule.

```
 count
-------
     4
(1 row)

```
after query result
```
 count
-------
     0
(1 row)
```
error message
```
Due to security restrictions, you are not allowed to modify 'Journal Entry' (account.move) records.

Records: Draft Invoice INV/2024/00001 (id=25)
User: Mitchell Admin (id=2)

This restriction is due to the following rules:
- Point Of Sale Account move

Contact your administrator to request access if necessary.
```
