### PR TITLE
[FIX] util/method: added variable to add_view

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -280,7 +280,7 @@ def edit_view(cr, xmlid=None, view_id=None, skip_if_not_noupdate=True, active="a
             )
 
 
-def add_view(cr, name, model, view_type, arch_db, inherit_xml_id=None, priority=16, key=None):
+def add_view(cr, name, model, view_type, arch_db, inherit_xml_id=None, priority=16, key=None, website_id=None):
     inherit_id = None
     if inherit_xml_id:
         inherit_id = ref(cr, inherit_xml_id)
@@ -311,6 +311,7 @@ def add_view(cr, name, model, view_type, arch_db, inherit_xml_id=None, priority=
             "priority": priority,
             "key": key,
             "arch_db": arch_column_value,
+            "website_id": website_id,
         },
     )
     return cr.fetchone()[0]


### PR DESCRIPTION
**Description:**

The util method `add_view` was previously used to create views for `view_type` such as form, tree, and qweb. However, it lacked support for setting the `website_id`, which limited its ability to create website-specific views.

This PR introduces a new `website_id` parameter to the `add_view` method. By adding this parameter, the method can now be used to create views specific to a website, enabling the creation of both backend views (form, tree, qweb) and frontend website views.

**Changes:**
- Added `website_id` parameter to the `add_view` method.
- Adjusted the SQL query to include `website_id` where applicable.
- Website views can now be created using this method by passing the appropriate `website_id`.

This enhancement makes the `add_view` method more flexible, supporting both regular and website-specific views.