### PR TITLE
[FIX] util.indirect_references: use table_name instead of model_name

### DIFF
--- a/src/util/indirect_references.py
+++ b/src/util/indirect_references.py
@@ -122,8 +122,8 @@ def indirect_references(cr, bound_only=False):
                AND ttype = 'many2one'
             """,
         )
-        for table_name, column_name, comodel_name in cr.fetchall():
-            yield IR(table_name, None, column_name, company_dependent_comodel=comodel_name)
+        for model_name, column_name, comodel_name in cr.fetchall():
+            yield IR(table_of_model(cr, model_name), None, column_name, company_dependent_comodel=comodel_name)
 
     # XXX Once we will get the model field of `many2one_reference` fields in the database, we should get them also
     # (and filter the one already hardcoded)


### PR DESCRIPTION
Otherwise errors (such as the following) will ensue.

```
2024-09-24 12:11:34,164 2158 ERROR matt-purchase odoo.upgrade.base.tests.test_util: ERROR: TestRecords.test_rename_xmlid
Traceback (most recent call last):
  File "/upgrade-util/src/base/tests/test_util.py", line 1030, in test_rename_xmlid
    res = util.rename_xmlid(cr, "base.TX1", "base.TX2", on_collision="merge")
  File "/upgrade-util/src/util/records.py", line 751, in rename_xmlid
    replace_record_references(cr, (model, old_id), (model, new_id), replace_xmlid=False)
  File "/upgrade-util/src/util/records.py", line 1308, in replace_record_references
    return replace_record_references_batch(cr, {old[1]: new[1]}, old[0], new[0], replace_xmlid)
  File "/upgrade-util/src/util/records.py", line 1490, in replace_record_references_batch
    explode_execute(cr, query, table=ir.table)
  File "/upgrade-util/src/util/pg.py", line 352, in explode_execute
    explode_query_range(cr, query, table, alias=alias, bucket_size=bucket_size),
  File "/upgrade-util/src/util/pg.py", line 259, in explode_query_range
    cr.execute(format_query(cr, "SELECT min(id), max(id) FROM {}", table))
  File "/tmp/tmpinhjowz1/odoo/pr/153463/odoo/sql_db.py", line 354, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UndefinedTable: relation "res.partner" does not exist
LINE 1: SELECT min(id), max(id) FROM "res.partner"
```