### PR TITLE
[IMP] *: Using class name corresponding to odoo models

### DIFF
--- a/src/base/0.0.0/pre-models-ir_model_relation.py
+++ b/src/base/0.0.0/pre-models-ir_model_relation.py
@@ -15,7 +15,8 @@ def migrate(cr, version):
 
 
 class ModelRelation(models.Model):
-    _inherit = "ir.model.relation"
+    _name = "ir.model.relation"
+    _inherit = ["ir.model.relation"]
     _module = "base"
 
     @api.model

--- a/src/mail/0.0.0/pre-report-migration.py
+++ b/src/mail/0.0.0/pre-report-migration.py
@@ -9,7 +9,10 @@ except ImportError:
         return f
 
 
-from odoo.addons.mail.models.mail_message import Message  # noqa
+try:
+    from odoo.addons.mail.models.mail_message import Message  # noqa
+except ImportError:
+    from odoo.addons.mail.models.mail_message import MailMessage
 
 from odoo.addons.base.maintenance.migrations import util
 
@@ -19,7 +22,7 @@ def migrate(cr, version):
 
 
 class MailMessage(models.Model):
-    _inherit = "mail.message"
+    _inherit = ["mail.message"]
     _module = "mail"
 
     @model_cr


### PR DESCRIPTION
If the class does not have the correct name, it is possible to force the
model name using `_name`.
In order to minimize changes for migration scripts, the solution of
forcing the `_name` is made instead of correcting the class names.