### PR TITLE
[FIX] json: make json and orjson more similar

### DIFF
--- a/src/util/json.py
+++ b/src/util/json.py
@@ -6,7 +6,7 @@ except ImportError:
     import json
 
     def dumps(value, sort_keys=False):
-        return json.dumps(value, sort_keys=sort_keys)
+        return json.dumps(value, sort_keys=sort_keys, separators=(",", ":"))
 
     def loads(value):
         return json.loads(value)

--- a/src/util/json.py
+++ b/src/util/json.py
@@ -16,6 +16,10 @@ except ImportError:
 else:
 
     def dumps(value, sort_keys=False):
+        if isinstance(value, tuple):
+            # downcast namedtuples
+            value = tuple(value)
+
         option = orjson.OPT_NON_STR_KEYS
         if sort_keys:
             option |= orjson.OPT_SORT_KEYS

--- a/src/util/json.py
+++ b/src/util/json.py
@@ -16,7 +16,9 @@ except ImportError:
 else:
 
     def dumps(value, sort_keys=False):
-        option = orjson.OPT_SORT_KEYS if sort_keys else None
+        option = orjson.OPT_NON_STR_KEYS
+        if sort_keys:
+            option |= orjson.OPT_SORT_KEYS
         return orjson.dumps(value, option=option).decode()
 
     def loads(value):


### PR DESCRIPTION
1- dict with null keys
json allows the dump of a dict with a null key
but orjson raises an error `TypeError: Dict key must be str`
-> add option orjson.OPT_NON_STR_KEYS to orjson dumps

2- dumping namedtuple
orjson cannot serialize namedtuple objects
'TypeError: Type is not JSON serializable'
-> cast it to tuple

3- spaces after separators
orjson does not include a space after commas and columns in string dumps
and it is not configurable to do so, we can instead configure json to remove 
them as well so we have an expected output regardless of which lib is being
used

Fixes are for failures in ci tests