### PR TITLE
[IMP] util/fields: update default when converting to html

### DIFF
--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -654,6 +654,19 @@ def convert_field_to_html(cr, model, field, skip_inherit=()):
         """,
         [field, model],
     )
+
+    # Update ir.default
+    if table_exists(cr, "ir_default"):
+        json_value_html = pg_text2html("json_value")
+        query = """
+                UPDATE ir_default AS d
+                   SET json_value = {}
+                  FROM ir_model_fields AS imf
+                 WHERE imf.name = %s
+                   AND imf.model = %s
+                   AND imf.id = d.field_id
+                """
+        cr.execute(format_query(cr, query, sql.SQL(json_value_html)), [field, model])
     for inh in for_each_inherit(cr, model, skip_inherit):
         convert_field_to_html(cr, inh.model, field, skip_inherit=skip_inherit)
 

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -398,14 +398,17 @@ def pg_text2html(s, wrap="p"):
         CASE WHEN TRIM(COALESCE({src}, '')) ~ '^<.+</\w+>$' THEN {src}
              ELSE CONCAT(
                 '{opening_tag}',
-                replace(REGEXP_REPLACE({esc},
-                                       -- regex from https://blog.codinghorror.com/the-problem-with-urls/
-                                       -- double the %% to allow this code chunk to be used in parameterized queries
-                                       'https?://[-A-Za-z0-9+&@#/%%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%%=~_()|]',
-                                       '<a href="\&" target="_blank" rel="noreferrer noopener">\&</a>',
-                                       'g'),
-                        E'\n',
-                        '<br>'),
+                replace(
+                    replace(REGEXP_REPLACE({esc},
+                                           -- regex from https://blog.codinghorror.com/the-problem-with-urls/
+                                           -- double the %% to allow this code chunk to be used in parameterized queries
+                                           'https?://[-A-Za-z0-9+&@#/%%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%%=~_()|]',
+                                           '<a href="\&" target="_blank" rel="noreferrer noopener">\&</a>',
+                                           'g'),
+                            E'\\n',
+                            '<br>'),
+                    E'\\t',
+                    '&Tab;'),
                 '{closing_tag}')
          END
     """.format(


### PR DESCRIPTION
One could use Python escape sequences in text fields. When converting a field to HTML, they will no longer work, so replace them with HTML tags.

Before:
```
+--------------------------------------------------------------------------------------------------------------------------------------+
| json_value                                                                                                                           |
|--------------------------------------------------------------------------------------------------------------------------------------|
| "Mise en place du chantier\n\nIntervention pour une mise en arrêt de la chaudière\n\nVérification responsable\nRepli fin de travaux" |
+--------------------------------------------------------------------------------------------------------------------------------------+
```
After:
```
+-----------------------------------------------------------------------------------------------------------------------------------------------------+
| json_value                                                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------------------------------------|
| "Mise en place du chantier<br/><br/>Intervention pour une mise en arrêt de la chaudière<br/><br/>Vérification responsable<br/>Repli fin de travaux" |
+-----------------------------------------------------------------------------------------------------------------------------------------------------+
```


[opw-4133947](https://www.odoo.com/odoo/project/6443/tasks/4133947)