### PR TITLE
[FIX] fields: keep values for some selections

### DIFF
--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -964,9 +964,9 @@ def change_field_selection_values(cr, model, field, mapping, skip_inherit=()):
               WHERE f.id = s.field_id
                 AND f.model = %s
                 AND f.name = %s
-                AND s.value IN %s
+                AND s.value = ANY(%s)
         """,
-        [model, field, tuple(mapping)],
+        [model, field, [k for k in mapping if k not in mapping.values()]],
     )
 
     def adapter(leaf, _or, _neg):


### PR DESCRIPTION
In change_field_selection_values when the mapping arg
contains keys that are also present in values, we do not
want to remove the values that are still valid