### PR TITLE
[FIX] util/misc: make SelfPrintEvalContext handle starred nodes

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1426,6 +1426,8 @@ class TestMisc(UnitTestCase):
                     "a",
                     "a.b" "a.b()",
                     "a.b(c)",
+                    "[('company_id', 'in', company_ids)]",
+                    "[]",
                 ]
                 + ["a {} 4".format(op) for op in ["+", "-", "*", "/", "//", "%"]]
                 + ["4 {} b".format(op) for op in ["+", "-", "*", "/", "//", "%"]]
@@ -1434,6 +1436,25 @@ class TestMisc(UnitTestCase):
     )
     def test_SelfPrint(self, value):
         evaluated = safe_eval(value, util.SelfPrintEvalContext(), nocopy=True)
+        self.assertEqual(str(evaluated), value, "Self printed result differs")
+
+        replaced_value, ctx = util.SelfPrintEvalContext.preprocess(value)
+        evaluated = safe_eval(replaced_value, ctx, nocopy=True)
+        self.assertEqual(str(evaluated), value, "Prepared self printed result differs")
+
+    @parametrize(
+        [
+            (value,)
+            for value in [
+                "[('company_id', 'in', [*company_ids, False])]",
+                "[('company_id', 'in', [False, *company_ids])]",
+            ]
+        ]
+    )
+    @unittest.skipUnless(util.ast_unparse is not None, "`ast.unparse` available from Python3.9")
+    def test_SelfPrint_prepare(self, value):
+        replaced_value, ctx = util.SelfPrintEvalContext.preprocess(value)
+        evaluated = safe_eval(replaced_value, ctx, nocopy=True)
         self.assertEqual(str(evaluated), value)
 
 

--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -196,12 +196,11 @@ def _adapt_one_domain(cr, target_model, old, new, model, domain, adapter=None, f
     if not adapter:
         adapter = lambda leaf, _, __: [leaf]
 
-    evaluation_context = SelfPrintEvalContext()
-
     # pre-check domain
     if isinstance(domain, basestring):
         try:
-            eval_dom = expression.normalize_domain(safe_eval(domain, evaluation_context, nocopy=True))
+            replaced_domain, ctx = SelfPrintEvalContext.preprocess(domain)
+            eval_dom = expression.normalize_domain(safe_eval(replaced_domain, ctx, nocopy=True))
         except Exception as e:
             oops = exception_to_unicode(e)
             _logger.log(NEARLYWARN, "Cannot evaluate %r domain: %r: %s", model, domain, oops)


### PR DESCRIPTION
The star operator is "external" to the `SelfPrint` object we try to convert to string. Thus it is impossible to override a dunder method that would return always the right answer. Overriding `__iter__` is out of question. For example, it could be triggered in at least two different ways: `[*obj]`, `[for x in obj]`. From `obj` we cannot decide which one it was, thus printing `*obj` always is wrong.

The strategy in this patch is to prepare the self printing context before evaluation such that it can deal with starred `*obj` nodes. The basic idea is to replace all `*obj` occurrences with unique names that the self printing object can later transform back to the right starred expression. To ensure correctness we use `ast` and its `unparse` method.