### PR TITLE
[IMP] all/saas~18.1: Make _name or _inherit mandatory

### DIFF
--- a/src/mail/0.0.0/pre-report-migration.py
+++ b/src/mail/0.0.0/pre-report-migration.py
@@ -22,7 +22,7 @@ def migrate(cr, version):
 
 
 class MailMessage(models.Model):
-    _inherit = ["mail.message"]
+    _inherit = "mail.message"
     _module = "mail"
 
     @model_cr


### PR DESCRIPTION
This is a request following the revert of the use of class names (concerning the python inheritance and typing project)

community: https://github.com/odoo/odoo/pull/189889
enterprise: https://github.com/odoo/enterprise/pull/75293