### PR TITLE
[IMP] util.misc.SelfPrint

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1430,16 +1430,21 @@ class TestMisc(UnitTestCase):
                 "a.b",
                 "a.b()",
                 "a.b(c)",
+                "a[b]",
+                "context['company_id']",
                 "[('company_id', 'in', company_ids)]",
                 "[]",
             ]
         ]
-        + [(f"a {op} 4", f"(a {op} 4)") for op in ["+", "-", "*", "/", "//", "%"]]
-        + [(f"4 {op} b", f"(4 {op} b)") for op in ["+", "-", "*", "/", "//", "%"]]
+        + [(f"a {op} 4", f"(a {op} 4)") for op in ["+", "-", "*", "/", "//", "%", "**"]]
+        + [(f"4 {op} b", f"(4 {op} b)") for op in ["+", "-", "*", "/", "//", "%", "**"]]
         + [
             ("a+b*c", "(a + (b * c))"),
             ("a+b/c-d", "((a + (b / c)) - d)"),
             ("(a+b) * c", "((a + b) * c)"),
+            ("+a", "+(a)"),
+            ("-a", "-(a)"),
+            ("-(a+b)", "-((a + b))"),
         ]
     )
     def test_SelfPrint(self, value, expected):

--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1428,7 +1428,8 @@ class TestMisc(UnitTestCase):
             for value in (
                 [
                     "a",
-                    "a.b" "a.b()",
+                    "a.b",
+                    "a.b()",
                     "a.b(c)",
                     "[('company_id', 'in', company_ids)]",
                     "[]",

--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1424,28 +1424,31 @@ class TestMisc(UnitTestCase):
 
     @parametrize(
         [
-            (value,)
-            for value in (
-                [
-                    "a",
-                    "a.b",
-                    "a.b()",
-                    "a.b(c)",
-                    "[('company_id', 'in', company_ids)]",
-                    "[]",
-                ]
-                + ["a {} 4".format(op) for op in ["+", "-", "*", "/", "//", "%"]]
-                + ["4 {} b".format(op) for op in ["+", "-", "*", "/", "//", "%"]]
-            )
+            (value, value)
+            for value in [
+                "a",
+                "a.b",
+                "a.b()",
+                "a.b(c)",
+                "[('company_id', 'in', company_ids)]",
+                "[]",
+            ]
+        ]
+        + [(f"a {op} 4", f"(a {op} 4)") for op in ["+", "-", "*", "/", "//", "%"]]
+        + [(f"4 {op} b", f"(4 {op} b)") for op in ["+", "-", "*", "/", "//", "%"]]
+        + [
+            ("a+b*c", "(a + (b * c))"),
+            ("a+b/c-d", "((a + (b / c)) - d)"),
+            ("(a+b) * c", "((a + b) * c)"),
         ]
     )
-    def test_SelfPrint(self, value):
+    def test_SelfPrint(self, value, expected):
         evaluated = safe_eval(value, util.SelfPrintEvalContext(), nocopy=True)
-        self.assertEqual(str(evaluated), value, "Self printed result differs")
+        self.assertEqual(str(evaluated), expected, "Self printed result differs")
 
         replaced_value, ctx = util.SelfPrintEvalContext.preprocess(value)
         evaluated = safe_eval(replaced_value, ctx, nocopy=True)
-        self.assertEqual(str(evaluated), value, "Prepared self printed result differs")
+        self.assertEqual(str(evaluated), expected, "Prepared self printed result differs")
 
     @parametrize(
         [

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -387,46 +387,46 @@ class SelfPrint(object):
         return SelfPrint("%r(%s)" % (self, ", ".join(s)))
 
     def __add__(self, other):
-        return SelfPrint("%r + %r" % (self, other))
+        return SelfPrint("(%r + %r)" % (self, other))
 
     def __radd__(self, other):
-        return SelfPrint("%r + %r" % (other, self))
+        return SelfPrint("(%r + %r)" % (other, self))
 
     def __sub__(self, other):
-        return SelfPrint("%r - %r" % (self, other))
+        return SelfPrint("(%r - %r)" % (self, other))
 
     def __rsub__(self, other):
-        return SelfPrint("%r - %r" % (other, self))
+        return SelfPrint("(%r - %r)" % (other, self))
 
     def __mul__(self, other):
-        return SelfPrint("%r * %r" % (self, other))
+        return SelfPrint("(%r * %r)" % (self, other))
 
     def __rmul__(self, other):
-        return SelfPrint("%r * %r" % (other, self))
+        return SelfPrint("(%r * %r)" % (other, self))
 
     def __div__(self, other):
-        return SelfPrint("%r / %r" % (self, other))
+        return SelfPrint("(%r / %r)" % (self, other))
 
     def __rdiv__(self, other):
-        return SelfPrint("%r / %r" % (other, self))
+        return SelfPrint("(%r / %r)" % (other, self))
 
     def __truediv__(self, other):
-        return SelfPrint("%r / %r" % (self, other))
+        return SelfPrint("(%r / %r)" % (self, other))
 
     def __rtruediv__(self, other):
-        return SelfPrint("%r / %r" % (other, self))
+        return SelfPrint("(%r / %r)" % (other, self))
 
     def __floordiv__(self, other):
-        return SelfPrint("%r // %r" % (self, other))
+        return SelfPrint("(%r // %r)" % (self, other))
 
     def __rfloordiv__(self, other):
-        return SelfPrint("%r // %r" % (other, self))
+        return SelfPrint("(%r // %r)" % (other, self))
 
     def __mod__(self, other):
-        return SelfPrint("%r %% %r" % (self, other))
+        return SelfPrint("(%r %% %r)" % (self, other))
 
     def __rmod__(self, other):
-        return SelfPrint("%r %% %r" % (other, self))
+        return SelfPrint("(%r %% %r)" % (other, self))
 
     def __repr__(self):
         return self.__name

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -380,6 +380,9 @@ class SelfPrint(object):
     def __getattr__(self, attr):
         return SelfPrint("%r.%s" % (self, attr))
 
+    def __getitem__(self, key):
+        return SelfPrint("%r[%r]" % (self, key))
+
     def __call__(self, *args, **kwargs):
         s = [repr(a) for a in args]
         for k, v in kwargs.items():
@@ -427,6 +430,18 @@ class SelfPrint(object):
 
     def __rmod__(self, other):
         return SelfPrint("(%r %% %r)" % (other, self))
+
+    def __pow__(self, other):
+        return SelfPrint("(%r ** %r)" % (self, other))
+
+    def __rpow__(self, other):
+        return SelfPrint("(%r ** %r)" % (other, self))
+
+    def __pos__(self):
+        return SelfPrint("+(%r)" % (self,))
+
+    def __neg__(self):
+        return SelfPrint("-(%r)" % (self,))
 
     def __repr__(self):
         return self.__name


### PR DESCRIPTION
While reviewing #170, I wanted to give an example of a real-world failure and stumble upon this expression:
```
("date_closed", ">=", datetime.datetime.combine(context_today() + relativedelta(months = -(context_today().month - 1) % 3, day = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S"))
```

This shown multiple things:
 - We didn't handle all operators (in this case, unary negative, but not only)
 - Since day 1 (11 years ago!), we wrongly supported operators order.

Further investigations also revealed that we didn't correctly support the `not` operator.