### PR TITLE
[IMP] util.records.uninstall_module: use `remove_group`

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -48,7 +48,7 @@ from .misc import on_CI, str2bool, version_gte
 from .models import delete_model
 from .orm import env, flush
 from .pg import column_exists, table_exists, target_of
-from .records import ref, remove_menus, remove_records, remove_view, replace_record_references_batch
+from .records import ref, remove_group, remove_menus, remove_records, remove_view, replace_record_references_batch
 
 INSTALLED_MODULE_STATES = ("installed", "to install", "to upgrade")
 _logger = logging.getLogger(__name__)
@@ -204,6 +204,9 @@ def uninstall_module(cr, module):
         if model == "ir.ui.view":
             for _, res_id in group:
                 remove_view(cr, view_id=res_id, silent=True)
+        elif model == "res.groups":
+            for _, res_id in group:
+                remove_group(cr, group_id=res_id)
         else:
             remove_records(cr, model, [it[1] for it in group])
 


### PR DESCRIPTION
In `uninstall_module` it is not using `remove_group` for records from model `res.groups` which leads to face **psycopg2.errors.ForeignKeyViolation** while removing the records from `res.groups`, if the group has relation
with _**ondelete=restrict**_.

**example**:
In [upg-2390919](https://upgrade.odoo.com/web#id=2390919&cids=1&menu_id=107&action=150&model=upgrade.request&view_type=form) the has `group_consolidation_user` has manually created referencing records in `ir.model.access` (ondelete=restrict).
So during the [removal](https://github.com/odoo/upgrade/blob/8191d819d6b0c630e2fec4b59c50b721f85ab8ce/migrations/base/saas~17.5.1.3/pre-10-modules.py#L38) of module `account_consolidation`, it causes the issue I mentioned above. 