### PR TITLE
[IMP] util.modules: new hack to override load data mode

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -895,6 +895,11 @@ def _force_upgrade_of_fresh_module(cr, module, init, version):
     # Low level implementation
     # Force module state to be in `to upgrade`.
     # Needed for migration script execution. See http://git.io/vnF7f
+    if version_gte("saas~18.2") and init:
+        env_ = env(cr)
+        env_.registry._force_upgrade_scripts.add(module)
+        return
+
     cr.execute(
         """
             UPDATE ir_module_module


### PR DESCRIPTION
The new runtime option 'load_data_init' will be used for each package when loading package graph. It works like the previous package.init but more comprehensive and complete. Now if any directly or indirectly dependent module is configured 'load_data_init', the module will also be configured 'load_data_init'

https://github.com/odoo/odoo/pull/189000