### PR TITLE
[FIX] models: save automated rule

### DIFF
--- a/src/util/models.py
+++ b/src/util/models.py
@@ -518,6 +518,15 @@ def merge_model(cr, source, target, drop_table=True, fields_mapping=None, ignore
                 "len_source": len(source) + 1,
             },
         )
+    if column_exists(cr, "base_automation", "model_id"):
+        cr.execute(
+            """
+            UPDATE base_automation
+               SET model_id = %s
+             WHERE model_id = %s
+            """,
+            [model_ids[target], model_ids[source]],
+        )
 
     remove_model(cr, source, drop_table=drop_table, ignore_m2m=ignore_m2m)
 


### PR DESCRIPTION
[here](https://github.com/odoo/upgrade-util/blob/c65f16e851c121584966280825d485ba51989e84/src/util/models.py#L172) deletion of ``base_automation`` is handled seperatly while removing model. So while merging the model
saving the automated action accordingly to prevent from deletion.

opw-4420421