### PR TITLE
[FIX] util/modules: fix discovery of no-deps modules

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -527,9 +527,9 @@ def force_install_module(cr, module, if_installed=None, reason="it has been expl
     cr.execute(
         """
         WITH RECURSIVE deps (mod_id, dep_name) AS (
-              SELECT m.id, d.name from ir_module_module_dependency d
-              JOIN ir_module_module m on (d.module_id = m.id)
-              WHERE m.name = %s
+              SELECT m.id, m.name
+                FROM ir_module_module m
+               WHERE m.name = %s
             UNION
               SELECT m.id, d.name from ir_module_module m
               JOIN deps ON deps.dep_name = m.name
@@ -543,7 +543,7 @@ def force_install_module(cr, module, if_installed=None, reason="it has been expl
                demo=(select demo from ir_module_module where name='base')
           FROM deps d
          WHERE m.id = d.mod_id
-           {0}
+           {}
      RETURNING m.name, m.state
     """.format(subquery),
         (module,) + subparams,
@@ -721,7 +721,7 @@ def trigger_auto_install(cr, module):
 
     dep_match = "true"
     if column_exists(cr, "ir_module_module_dependency", "auto_install_required"):
-        dep_match = "d.auto_install_required = true"
+        dep_match = "COALESCE(d.auto_install_required, true) = true"
 
     country_match = country_join = ""
     if table_exists(cr, "module_country"):
@@ -753,9 +753,11 @@ def trigger_auto_install(cr, module):
 
     query = """
             SELECT m.id
-              FROM ir_module_module_dependency d
-              JOIN ir_module_module m ON m.id = d.module_id
-              JOIN ir_module_module md ON md.name = d.name
+              FROM ir_module_module m
+         LEFT JOIN ir_module_module_dependency d
+                ON m.id = d.module_id
+         LEFT JOIN ir_module_module md
+                ON md.name = d.name
                 {}
              WHERE m.name = %s
                AND m.state = 'uninstalled'
@@ -763,7 +765,7 @@ def trigger_auto_install(cr, module):
                AND {}
                AND {}
           GROUP BY m.id
-            HAVING bool_and(md.state IN %s)
+            HAVING (bool_and(md.state IN %s) OR count(d.id) = 0)
                 {}
     """.format(country_join, dep_match, cat_match, country_match)
 


### PR DESCRIPTION
When a module has no explicit dependency (e.g. pure JS module) and it is `autoinstall=True` the current dicovery mechanism completely ignores them.

In this patch we ensure that such dependecy-less modules are also handled.