### PR TITLE
[FIX] Don't try to discover non-installable modules

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -939,6 +939,8 @@ def _trigger_auto_discovery(cr):
     graph = {}
     for module in odoo.modules.get_modules():
         manifest = get_manifest(module)
+        if not manifest.get("installable", True):
+            continue
         graph[module] = (
             set(manifest["depends"]),
             manifest["auto_install"],


### PR DESCRIPTION
Without this patch, if there's any module with installable=False found while running `post-01-modules-auto-discovery.py`, it will fail.

<details>

```
2025-01-15 12:09:09,972 1 INFO ? odoo.modules.migration: module base: Running migration [0.0.0>] post-01-modules-auto-discovery 
2025-01-15 12:09:12,738 1 WARNING ? odoo.modules.loading: Transient module states were reset 
2025-01-15 12:09:12,742 1 ERROR ? odoo.modules.registry: Failed to load registry 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 430, in load_modules
    loaded_modules, processed_modules = load_module_graph(
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 237, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/opt/odoo/custom/src/odoo/odoo/modules/migration.py", line 189, in migrate_module
    migrate(self.cr, installed_version)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/base/0.0.0/post-01-modules-auto-discovery.py", line 8, in migrate
    _trigger_auto_discovery(cr)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 958, in _trigger_auto_discovery
    module_deps_diff(cr, module, plus=plus, minus=minus)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 687, in module_deps_diff
    new_module_dep(cr, module, new_dep)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 643, in new_module_dep
    _assert_modules_exists(cr, module, new_dep)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 638, in _assert_modules_exists
    raise AssertionError("Unexisting modules: {}".format(", ".join(unexisting_modules)))
AssertionError: Unexisting modules: base_address_city
2025-01-15 12:09:12,744 1 ERROR ? click_odoo.env_options: exception 
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/click_odoo/env_options.py", line 194, in _invoke
    with self.environment_manager(
  File "/usr/local/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/usr/local/lib/python3.10/site-packages/click_odoo_contrib/update.py", line 299, in OdooEnvironmentWithUpdate
    _update_db(
  File "/usr/local/lib/python3.10/site-packages/click_odoo_contrib/update.py", line 270, in _update_db
    _update_db_nolock(
  File "/usr/local/lib/python3.10/site-packages/click_odoo_contrib/update.py", line 248, in _update_db_nolock
    odoo.modules.registry.Registry.new(database, update_module=True)
  File "<decorator-gen-16>", line 2, in new
  File "/opt/odoo/custom/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 430, in load_modules
    loaded_modules, processed_modules = load_module_graph(
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 237, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/opt/odoo/custom/src/odoo/odoo/modules/migration.py", line 189, in migrate_module
    migrate(self.cr, installed_version)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/base/0.0.0/post-01-modules-auto-discovery.py", line 8, in migrate
    _trigger_auto_discovery(cr)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 958, in _trigger_auto_discovery
    module_deps_diff(cr, module, plus=plus, minus=minus)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 687, in module_deps_diff
    new_module_dep(cr, module, new_dep)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 643, in new_module_dep
    _assert_modules_exists(cr, module, new_dep)
  File "/usr/local/lib/python3.10/site-packages/odoo/upgrade/util/modules.py", line 638, in _assert_modules_exists
    raise AssertionError("Unexisting modules: {}".format(", ".join(unexisting_modules)))
AssertionError: Unexisting modules: base_address_city
Error: Unexisting modules: base_address_city
```

</details>

@moduon MT-3426