### PR TITLE
[FIX] util/records: reset translations for all languages

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1183,11 +1183,15 @@ def __update_record_from_xml(
             [("name", "=", from_module), ("state", "=", "installed")]
         )
         if module_to_reload_from:
-            if hasattr(module_to_reload_from, "_update_translations"):
-                module_to_reload_from._update_translations()
-            else:
-                # < 9.0
-                module_to_reload_from.update_translations()
+            if version_gte("14.0"):
+                module_to_reload_from._update_translations(overwrite=True)
+            elif version_gte("11.0"):
+                module_to_reload_from.with_context(overwrite=True)._update_translations()
+            elif version_gte("10.0"):
+                module_to_reload_from.with_context(overwrite=True).update_translations()
+            # Not tested - no use cases in current odoo/upgrade code.
+            # elif version_gte("7.0"):
+            #     module_to_reload_from.update_translations(cr, SUPERUSER_ID, [module_to_reload_from.id], None, context={"overwrite": True})
 
 
 def delete_unused(cr, *xmlids, **kwargs):


### PR DESCRIPTION
This commit modifies `update_record_from_xml()` to ensure that translations are updated in _all_ languages by adding the `overwrite` parameter when calling `_update_translations()`.
Without this parameter, existing translations are only overwritten if they are identical to the `en_US` translation, which is not a true reset. This can be a particular issue with mail templates.

Related tests have been updated.

It also handles Odoo versions correctly.
