### PR TITLE
[IMP] IndirectReference.model_filter

### DIFF
--- a/src/util/indirect_references.py
+++ b/src/util/indirect_references.py
@@ -27,7 +27,8 @@ class IndirectReference(
 
 
 # By default, there is no `res_id`, no `res_model_id` and it is deleted when the linked model is removed
-IndirectReference.__new__.__defaults__ = (None, None, False)  # https://stackoverflow.com/a/18348004
+# warning: defaults are from the last fields in the namedtuple
+IndirectReference.__new__.__defaults__ = (None, None, False, None)  # https://stackoverflow.com/a/18348004
 
 
 def indirect_references(cr, bound_only=False):

--- a/src/util/indirect_references.py
+++ b/src/util/indirect_references.py
@@ -19,6 +19,10 @@ class IndirectReference(
         else:
             column = self.res_model
 
+        if column is None:
+            # `model` is not set when `company_dependent_comodel` is.
+            return "(false AND {} IS NULL)".format(placeholder)
+
         return '{}"{}"={}'.format(prefix, column, placeholder)
 
 


### PR DESCRIPTION
Handle `company_dependent_comodel` in the `model_filter` method. When it's set, there is no model, so return `false` (sql boolean).