### PR TITLE
[FIX] util/records: add root user check

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -591,8 +591,9 @@ def is_changed(cr, xmlid, interval="1 minute"):
            -- Note: use a negative search to handle the case of NULL values in write/create_date
            AND COALESCE(r.write_date < p.value::timestamp, True)
            AND r.write_date - r.create_date > interval %s
+           AND r.write_uid <> %s
         """.format(table),
-        [res_id, interval],
+        [res_id, interval, ref(cr, "base.user_root")],
     )
     return bool(cr.rowcount)
 


### PR DESCRIPTION
**Description:**
- In most cases, this fix: odoo/upgrade@bc4a020d334ee15263b6f9992528645a17ea000f will not work. These cases occur for databases that already have a migration history `(i.e., 16 → 17 → 18)` or when a manual upgrade of a module has been performed by the client via the UI. In such scenarios, there is a high possibility that the `write_date` has been updated by the root user, exceeding the internal time limit (1 minute). Due to which the actual purpose of `if_unchanged` is not delivered.

**Solution:**
- To handle such cases, a check of the `write_uid` is essential.

Another scenario would be a record, `base.demo`, marked as `noupdate=True` in version A. 
Upon upgrading the database to version B, the record undergoes significant changes in the XML. 
To update the record, `update_record_from_xml` is performed during the migration. 
This process updates the `write_date` of the record with the root user.

Now, if a new version C upgrade occurs and the same record is updated using 
`util.if_unchanged(cr, "base.demo", util.update_record_from_xml)`, it will not be effective in this case.