### PR TITLE
[IMP] explode_query_range: prevent two small final buckets and remove deprecated kwarg from signature

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -238,7 +238,7 @@ def explode_query(cr, query, alias=None, num_buckets=8, prefix=None):
     return [cr.mogrify(query, [num_buckets, index]).decode() for index in range(num_buckets)]
 
 
-def explode_query_range(cr, query, table, alias=None, bucket_size=10000, prefix=None):
+def explode_query_range(cr, query, table, alias=None, bucket_size=10000, **kwargs):
     """
     Explode a query to multiple queries that can be executed in parallel.
 
@@ -246,6 +246,10 @@ def explode_query_range(cr, query, table, alias=None, bucket_size=10000, prefix=
 
     :meta private: exclude from online docs
     """
+    prefix = kwargs.pop("prefix", None)
+    for key in kwargs:
+        _logger.getChild("explode_query_range").error("The %r argument is not supported and will be ignored.", key)
+
     if prefix is not None:
         if alias is not None:
             raise ValueError("Cannot use both `alias` and deprecated `prefix` arguments.")


### PR DESCRIPTION
### [IMP] explode_query_range: remove deprecated kwarg from signature

The `prefix` keyword argument has long been deprecated and while it is still
supported for legacy reasons, it can be removed from the method's signature.

### [IMP] explode_query_range: prevent two small final buckets

In the extreme case, the last bucket could target as little as 1 record.
If the two final buckets, combined, target less than 110% the `bucket_size`:
combine them.