### PR TITLE
[FIX] util: import hr_payroll

### DIFF
--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -16,3 +16,4 @@ from .pg import *
 from .records import *
 from .report import *
 from .specific import *
+from .hr_payroll import *


### PR DESCRIPTION
hr_payroll file was added but never imported in __init__.py file.