### PR TITLE
[FIX] models: keep attachments when removing inherited field

### DIFF
--- a/src/util/models.py
+++ b/src/util/models.py
@@ -583,8 +583,10 @@ def remove_inherit_from_model(cr, model, inherit, keep=(), skip_inherit=(), with
                 and not ir.company_dependent_comodel
             ]
             for ir in irs:
-                query = format_query(cr, "DELETE FROM {} WHERE ({})", ir.table, sql.SQL(ir.model_filter()))
-                cr.execute(query, [model])  # cannot be executed in parallel. See git blame.
+                query = cr.mogrify(
+                    format_query(cr, "DELETE FROM {} WHERE ({})", ir.table, sql.SQL(ir.model_filter())), [model]
+                ).decode()
+                explode_execute(cr, query, table=table, bucket_size=1000)
         remove_field(cr, model, field, skip_inherit="*")  # inherits will be removed by the recursive call.
 
     # down on inherits of `model`


### PR DESCRIPTION
When removing indirect references for inherited attachment fields, we would be deleting all attachments on a certain model regardless of the field that uses it due to the use of the model filter alone.
To avoid this issue where multiple fields use attachments on the same model, we can skip attachments altogether. The call to remove_field later will cleanup any attachment records that have a res_field that matches the field being removed.
When a field with attachment is being removed using the remove_inherit, it should be cleaned up or handled clearly.

We can also now run the delete in parallel since https://github.com/odoo/upgrade-util/pull/49 with a smaller bucket size than the default

And combine all conditions on the IR to delete 