### PR TITLE
[IMP] fields: use ignored field for respawn

### DIFF
--- a/src/base/0.0.0/end-no-respawn-fields.py
+++ b/src/base/0.0.0/end-no-respawn-fields.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 
 from psycopg2.extras import execute_values
 
@@ -40,10 +41,22 @@ def migrate(cr, version):
     """
     )
 
+    key = "field_respawn:"
+    ignored_fields_respawn = {
+        e[len(key) :]
+        for e in os.environ.get("suppress_upgrade_warnings", "").split(",")  # noqa: SIM112
+        if e.startswith(key)
+    }
+
     for model, field, transient, store in cr.fetchall():
         qualifier = "field" if store else "non-stored field"
         if transient:
             qualifier = "transient " + qualifier
         lvl = util.NEARLYWARN if transient or not store else logging.CRITICAL
+        action = ""
 
-        _logger.log(lvl, "%s %s/%s has respawn!", qualifier, model, field)
+        if "{}/{}".format(model, field) in ignored_fields_respawn:
+            lvl = util.NEARLYWARN
+            action = "; explicitly ignored"
+
+        _logger.log(lvl, "%s %s/%s has respawn%s.", qualifier, model, field, action)


### PR DESCRIPTION
When a field reappears after an upgrade, a log with the format "field ... has respawn!" is emited. In some case, it is possible that this error should be silenced.

The current case was because an upgrade script targeting 18.2 was merged during the freeze and should target 18.3. During a short time frame after a freeze, some branch may be tested without testing the upgrade from the freshly created branch since no template are available.

In this case, a script was merged with an invalid version number. A pull request (#7240) was created to fix it but it took some time to be merged and then to be used by latest builds.

An exeption was added in master, fixing the 18.2-> master but this exception was not working for the 18.*->18.2 error. This commit will use the same exception to silence this error allowing quick fixes in this kind of situation.

Note that this pr was merged with https://github.com/odoo/upgrade/pull/7261 in order to use this silence mechanism to  backport a feature from 18.3 to 18.2