### PR TITLE
[IMP] util/report: do not show None or empty link

### DIFF
--- a/src/util/report.py
+++ b/src/util/report.py
@@ -289,6 +289,8 @@ def announce(
 
 def get_anchor_link_to_record(model, id, name, action_id=None):
     _validate_model(model)
+    if not name:
+        name = "{}(id={})".format(model, id)
     if version_gte("saas~17.2"):
         part1 = "action-{}".format(action_id) if action_id else model
         url = "/odoo/{}/{}?debug=1".format(part1, id)


### PR DESCRIPTION
Sometimes we get unexpected empty (or NULL) values in some records when reporting about them. To avoid `None` or just an empty link we make a default value for `name` in such cases.