### PR TITLE
[IMP] inconsistencies, report

### DIFF
--- a/src/util/report.py
+++ b/src/util/report.py
@@ -105,6 +105,11 @@ def add_to_migration_reports(message, category="Other", format="text"):
         else:
             raw = True
     migration_reports.setdefault(category, []).append((message, raw))
+    migration_reports_length = sum(len(msg) for reps in migration_reports.values() for msg, _ in reps) + sum(
+        map(len, migration_reports)
+    )
+    if migration_reports_length > 1000000:
+        _logger.warning("Upgrade report is growing suspiciously long: %s characters so far.", migration_reports_length)
 
 
 def announce_release_note(cr):


### PR DESCRIPTION
tbg-1840

Otherwise we eventually run into memory errors when announcing the report.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/16.0/odoo/service/server.py", line 1323, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/16.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/16.0/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/16.0/odoo/modules/loading.py", line 620, in load_modules
    model._register_hook()
  File "/tmp/tmpa7ynrpyl/migrations/mail/0.0.0/pre-report-migration.py", line 32, in _register_hook
    util.announce_migration_report(self.env.cr)
  File "/tmp/tmpa7ynrpyl/migrations/util/report.py", line 149, in announce_migration_report
    _announce_to_db(cr, message)
  File "/tmp/tmpa7ynrpyl/migrations/util/report.py", line 158, in _announce_to_db
    if message.strip():
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/markupsafe/__init__.py", line 178, in func
    return self.__class__(orig(self, *args, **kwargs))
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/markupsafe/__init__.py", line 74, in __new__
    return text_type.__new__(cls, base)
MemoryError
```

---

[IMP] report: warn when writing long message to migration report

Making it easier to prevent and/or identify problematic (i.e. overly long)
message insertions.