### PR TITLE
[FIX] util: Fix json decoder error

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1788,3 +1788,20 @@ class TestReplaceRecordReferences(UnitTestCase):
         util.replace_record_references_batch(cr, mapping, "res.groups")
         util.invalidate(u2)
         self.assertEqual(u2[groups].ids, [g3.id])
+
+
+class TestConvertFieldToHtml(UnitTestCase):
+    def test_convert_field_to_html(self):
+        cr = self.env.cr
+
+        model = self.env["ir.model"].search([("model", "=", "res.partner")])
+        f1 = self.env["ir.model.fields"].create(
+            {"name": "x_testx", "model": "res.partner", "ttype": "text", "model_id": model.id, "translate": True}
+        )
+        partner = self.env["res.partner"].create({"name": "test Pxtner", "x_testx": "test partner field"})
+        default = self.env["ir.default"].create({"field_id": f1.id, "json_value": '"Test text"'})
+        util.convert_field_to_html(cr, "res.partner", "x_testx")
+        util.invalidate(default)
+
+        self.assertEqual(default.json_value, '"<p>Test text</p>"')
+        self.assertEqual(partner.x_testx, "<p>test partner field</p>")

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -676,10 +676,10 @@ def convert_field_to_html(cr, model, field, skip_inherit=()):
 
     # Update ir.default
     if table_exists(cr, "ir_default"):
-        json_value_html = pg_text2html("json_value")
+        json_value_html = pg_text2html("json_value::json #>> '{}'")
         query = """
                 UPDATE ir_default AS d
-                   SET json_value = {}
+                   SET json_value = to_json(({})::text)::text
                   FROM ir_model_fields AS imf
                  WHERE imf.name = %s
                    AND imf.model = %s


### PR DESCRIPTION
after this [commit](https://github.com/odoo/upgrade-util/commit/41b82ab020c77dff5f88f2af0357a75cb8521629) now default value while converting field from text to html are also saved but here default value is saved as ``<p>"test"</p>`` but this not correct because at the it will load by [json](https://github.com/odoo/odoo/blob/602ef86b8dcad9c5a08ab034abf3ef51104104bc/odoo/addons/base/models/ir_default.py#L181) here if it won't have double quotes in starting.
So, below mentioned traceback will raise

orignal
```
 select imf.id,imf.ttype,id.json_value,name from ir_model_fields imf join ir_default id on id.field_id = imf.id
where imf.id=5078;
  id  | ttype | json_value  | name
------+-------+-------------+------
 5078 | text  | "- 5 years" | note
(1 row)

```

before fix
```
sagu_18.0=> select imf.id,imf.ttype,id.json_value,name from ir_model_fields imf join ir_default id on id.field_id = imf.id
where imf.id=5078;
  id  | ttype |     json_value     | name
------+-------+--------------------+------
 5078 | html  | <p>"- 5 years"</p> | note
(1 row)
```

after fix
```
sagu_18.0=> select imf.id,imf.ttype,id.json_value,name from ir_model_fields imf join ir_default id on id.field_id = imf.id
where imf.id=5078;
  id  | ttype |     json_value     | name
------+-------+--------------------+------
 5078 | html  | "<p>- 5 years</p>" | note
(1 row)

```

```
Traceback (most recent call last):
   File "/tmp/tmpfy9gg1vf/migrations/base/tests/test_mock_crawl.py", line 259, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpfy9gg1vf/migrations/base/tests/test_mock_crawl.py", line 272, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpfy9gg1vf/migrations/base/tests/test_mock_crawl.py", line 432, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpfy9gg1vf/migrations/base/tests/test_mock_crawl.py", line 460, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 3801, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4032, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 6999, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1328, in __get__
    defaults = record.default_get([self.name])
   File "/home/odoo/src/odoo/18.0/addons/utm/models/utm_mixin.py", line 27, in default_get
    values = super(UtmMixin, self).default_get(fields)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 1621, in default_get
    ir_defaults = self.env['ir.default']._get_model_defaults(self._name)
   File "<decorator-gen-67>", line 2, in _get_model_defaults
   File "/home/odoo/src/odoo/18.0/odoo/tools/cache.py", line 110, in lookup
    value = d[key] = self.method(*args, **kwargs)
   File "/home/odoo/src/odoo/18.0/odoo/addons/base/models/ir_default.py", line 181, in _get_model_defaults
    result[row[0]] = json.loads(row[1])
   File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
   File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
   File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
 json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

upg-2572973