### PR TITLE
[IMP] specific: check author in `rename_custom_module`

### DIFF
--- a/src/util/specific.py
+++ b/src/util/specific.py
@@ -81,13 +81,13 @@ def rename_custom_model(cr, model_name, new_model_name, custom_module=None, repo
     )
 
 
-def rename_custom_module(cr, old_module_name, new_module_name, report_details=""):
-    cr.execute("SELECT 1 FROM ir_module_module WHERE name = %s", [old_module_name])
+def rename_custom_module(cr, old_module_name, new_module_name, report_details="", author="%"):
+    cr.execute("SELECT 1 FROM ir_module_module WHERE name = %s AND author ILIKE %s", [old_module_name, author])
     if not cr.rowcount:
-        _logger.warning("Module %r not found: skip renaming", old_module_name)
         return
 
     rename_module(cr, old_module_name, new_module_name)
+    _logger.warning("Custom module %r renamed to %r", old_module_name, new_module_name)
     add_to_migration_reports(
         category="Custom modules",
         message="The custom module '{old_module_name}' was renamed to '{new_module_name}'. {report_details}".format(


### PR DESCRIPTION
When plenty of dbs exhibit the same custom (e.g. a `l10n`) module that needs to be renamed, we may use this util in generic scripts. In that case, it becomes paramount to make sure we only rename a specific module by a specific author. Actually, it would be better to do so in specific scripts too.

Also decrease the logger note level to info. It's not really a problem if the util is called against a db and the module is not found, perhaps the customer took care of the issue before submitting the new dump. Either way it's nothing to be concerned about.