### PR TITLE
[REF] odoo: remove test code from registry and sql_db

### DIFF
--- a/src/testing.py
+++ b/src/testing.py
@@ -344,8 +344,11 @@ class IntegrityCase(UpgradeCommon, _create_meta(20, "integrity_case")):
         super(IntegrityCase, self)._setup_registry()
         cr = self.registry.cursor()
         self.addCleanup(cr.close)
-        self.registry.enter_test_mode(cr)
-        self.addCleanup(self.registry.leave_test_mode)
+        if hasattr(self, "registry_enter_test_mode"):
+            self.registry_enter_test_mode(cr=cr)
+        else:
+            self.registry.enter_test_mode(cr)
+            self.addCleanup(self.registry.leave_test_mode)
 
     def setUp(self):
         super(IntegrityCase, self).setUp()


### PR DESCRIPTION
`Registry.enter_test_mode` has been removed in favor of a method on `BaseCase`.