### PR TITLE
[IMP] util,base: use cursor's mangled names

### DIFF
--- a/src/base/0.0.0/end-no-respawn-fields.py
+++ b/src/base/0.0.0/end-no-respawn-fields.py
@@ -20,7 +20,7 @@ def migrate(cr, version):
     """
     )
     execute_values(
-        cr._obj,
+        getattr(cr, '_obj__', None) or cr._obj,
         "INSERT INTO no_respawn(model, field) VALUES %s",
         # fmt:off
         [

--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -28,6 +28,7 @@ from odoo.addons.base.maintenance.migrations.util.domains import (
     _model_of_path,
 )
 from odoo.addons.base.maintenance.migrations.util.exceptions import MigrationError
+from odoo.addons.base.maintenance.migrations.util.pg import cursor_get_connection
 
 USE_ORM_DOMAIN = util.misc.version_gte("saas~18.2")
 NOTNOT = () if USE_ORM_DOMAIN else ("!", "!")
@@ -842,7 +843,7 @@ class TestPG(UnitTestCase):
     def test_ColumnList(self):
         cr = self.env.cr
 
-        s = lambda c: c.as_string(cr._cnx)
+        s = lambda c: c.as_string(cursor_get_connection(cr))
 
         columns = util.ColumnList(["a", "A"], ['"a"', '"A"'])
         self.assertEqual(len(columns), 2)

--- a/src/testing.py
+++ b/src/testing.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from . import util
 from .util import json
+from .util.pg import cursor_get_connection
 
 _logger = logging.getLogger(__name__)
 
@@ -142,7 +143,7 @@ class UpgradeCommon(BaseCase):
             ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value
         """.format(DATA_TABLE)
         self._data_table_cr.execute(query, (key, value))
-        self._data_table_cr._cnx.commit()
+        cursor_get_connection(self._data_table_cr).commit()
 
     def _get_value(self, key):
         self._init_db()
@@ -169,7 +170,7 @@ class UpgradeCommon(BaseCase):
                     value JSONB NOT NULL
                 )""".format(DATA_TABLE)
                 self._data_table_cr.execute(query)
-                self._data_table_cr._cnx.commit()
+                cursor_get_connection(self._data_table_cr).commit()
             UpgradeCommon.__initialized = True
 
     def _setup_registry(self):
@@ -355,7 +356,7 @@ class IntegrityCase(UpgradeCommon, _create_meta(20, "integrity_case")):
 
         def commit(self):
             if self.dbname == config["log_db"].split("/")[-1]:
-                self._cnx.commit()
+                cursor_get_connection(self).commit()
             else:
                 raise RuntimeError("Commit is forbidden in integrity cases")
 

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -53,6 +53,7 @@ from .pg import (
     alter_column_type,
     column_exists,
     column_type,
+    cursor_get_connection,
     explode_execute,
     explode_query_range,
     format_query,
@@ -898,7 +899,7 @@ def convert_binary_field_to_attachment(cr, model, field, encoded=True, name_fiel
     [count] = cr.fetchone()
 
     A = env(cr)["ir.attachment"]
-    iter_cur = cr._cnx.cursor("fetch_binary")
+    iter_cur = cursor_get_connection(cr).cursor("fetch_binary")
     iter_cur.itersize = 1
     iter_cur.execute(
         format_query(
@@ -1484,7 +1485,7 @@ def update_server_actions_fields(cr, src_model, dst_model=None, fields_mapping=N
         )
     else:
         psycopg2.extras.execute_values(
-            cr._obj,
+            getattr(cr, '_obj__') or cr._obj,
             """
             WITH field_ids AS (
                 SELECT mf1.id as old_field_id, mf2.id as new_field_id

--- a/src/util/inconsistencies.py
+++ b/src/util/inconsistencies.py
@@ -9,7 +9,7 @@ from psycopg2.sql import SQL
 
 from .helpers import _validate_model, table_of_model
 from .misc import Sentinel, chunks, str2bool
-from .pg import format_query, get_value_or_en_translation, target_of
+from .pg import cursor_get_connection, format_query, get_value_or_en_translation, target_of
 from .report import add_to_migration_reports, get_anchor_link_to_record, html_escape
 
 _logger = logging.getLogger(__name__)
@@ -228,7 +228,7 @@ def verify_uoms(
     _validate_model(model)
     table = table_of_model(cr, model)
 
-    q = lambda s: quote_ident(s, cr._cnx)
+    q = lambda s: quote_ident(s, cursor_get_connection(cr))
 
     if include_archived_products is FROM_ENV:
         include_archived_products = INCLUDE_ARCHIVED_PRODUCTS
@@ -404,7 +404,7 @@ def verify_products(
     table = table_of_model(cr, model)
     foreign_table = table_of_model(cr, foreign_model)
 
-    q = lambda s: quote_ident(s, cr._cnx)
+    q = lambda s: quote_ident(s, cursor_get_connection(cr))
 
     if include_archived_products is FROM_ENV:
         include_archived_products = INCLUDE_ARCHIVED_PRODUCTS

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -217,7 +217,7 @@ def format_query(cr, query, *args, **kwargs):
 
     args = tuple(wrap(a) for a in args)
     kwargs = {k: wrap(v) for k, v in kwargs.items()}
-    return SQLStr(sql.SQL(query).format(*args, **kwargs).as_string(cr._cnx))
+    return SQLStr(sql.SQL(query).format(*args, **kwargs).as_string(cursor_get_connection(cr)))
 
 
 def explode_query(cr, query, alias=None, num_buckets=8, prefix=None):
@@ -557,7 +557,7 @@ def create_column(cr, table, column, definition, **kwargs):
         fk = (
             sql.SQL("REFERENCES {}(id) ON DELETE {}")
             .format(sql.Identifier(fk_table), sql.SQL(on_delete_action))
-            .as_string(cr._cnx)
+            .as_string(cursor_get_connection(cr))
         )
     elif on_delete_action is not no_def:
         raise ValueError("`on_delete_action` argument can only be used if `fk_table` argument is set.")
@@ -845,7 +845,7 @@ def get_index_on(cr, table, *columns):
     """
     _validate_table(table)
 
-    if cr._cnx.server_version >= 90500:
+    if cursor_get_connection(cr).server_version >= 90500:
         position = "array_position(x.indkey, x.unnest_indkey)"
     else:
         # array_position does not exists prior postgresql 9.5
@@ -980,10 +980,10 @@ class ColumnList(UserList, sql.Composable):
         >>> list(columns)
         ['id', '"field_Yx"']
 
-        >>> columns.using(alias="t").as_string(cr._cnx)
+        >>> columns.using(alias="t").as_string(cursor_get_connection(cr))
         '"t"."id", "t"."field_Yx"'
 
-        >>> columns.using(leading_comma=True).as_string(cr._cnx)
+        >>> columns.using(leading_comma=True).as_string(cursor_get_connection(cr))
         ', "id", "field_Yx"'
 
         >>> util.format_query(cr, "SELECT {} t.name FROM table t", columns.using(alias="t", trailing_comma=True))
@@ -1026,7 +1026,7 @@ class ColumnList(UserList, sql.Composable):
 
         :param list(str) list_: list of unquoted column names
         """
-        quoted = [quote_ident(c, cr._cnx) for c in list_]
+        quoted = [quote_ident(c, cursor_get_connection(cr)) for c in list_]
         return cls(list_, quoted)
 
     def using(self, leading_comma=KEEP_CURRENT, trailing_comma=KEEP_CURRENT, alias=KEEP_CURRENT):
@@ -1482,7 +1482,8 @@ def get_m2m_tables(cr, table):
 
 class named_cursor(object):
     def __init__(self, cr, itersize=None):
-        self._ncr = cr._cnx.cursor("upg_nc_" + uuid.uuid4().hex, withhold=True)
+        pgconn = cursor_get_connection(cr)
+        self._ncr = pgconn.cursor("upg_nc_" + uuid.uuid4().hex, withhold=True)
         if itersize:
             self._ncr.itersize = itersize
 
@@ -1571,3 +1572,9 @@ def create_id_sequence(cr, table, set_as_default=True):
                 table=table_sql,
             )
         )
+
+
+def cursor_get_connection(cursor):
+    if hasattr(cursor, '_cnx__'):
+        return cursor._cnx__
+    return cursor._cnx

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1476,7 +1476,7 @@ def replace_record_references_batch(cr, id_mapping, model_src, model_dst=None, r
         ignores.append("ir_model_data")
 
     cr.execute("CREATE UNLOGGED TABLE _upgrade_rrr(old int PRIMARY KEY, new int)")
-    execute_values(cr, "INSERT INTO _upgrade_rrr (old, new) VALUES %s", id_mapping.items())
+    execute_values(getattr(cr, '_obj__', cr), "INSERT INTO _upgrade_rrr (old, new) VALUES %s", id_mapping.items())
 
     if model_src == model_dst:
         fk_def = []


### PR DESCRIPTION
  - The psycopg2 technical objects are now mangled inside the Odoo cursors. This is made to avoid using them improperly. So we must adapt the code to use new names.

Related to:

https://github.com/odoo/odoo/pull/204273
https://github.com/odoo/enterprise/pull/82655
https://github.com/odoo/upgrade/pull/7478