### PR TITLE
[FIX] util/fields: ensure order update on rename field

### DIFF
--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -1159,6 +1159,17 @@ def _update_field_usage_multi(cr, models, old, new, domain_adapter=None, skip_in
         "models": tuple(only_models) if only_models else (),
     }
 
+    # update order in ir.model
+    if column_exists(cr, "ir_model", "order") and only_models:
+        cr.execute(
+            rf"""
+            UPDATE ir_model
+               SET "order" = REGEXP_REPLACE("order", '(^|[\s,]){old}([\s,]|$)', '\1{new}\2')
+             WHERE model IN %s
+            """,
+            [only_models],
+        )
+
     # ir.action.server
     if column_exists(cr, "ir_act_server", "update_path") and only_models:
         cr.execute(


### PR DESCRIPTION
**Issue:**
When a field is renamed using rename_field, the ordering defined in `ir.model` is not updated accordingly. This leads to an error when the `_order_field_to_sql` method is triggered, as it attempts to get the field using the old name.

https://github.com/odoo/odoo/blob/b1666c61bbc9d7e7b920483e168c6048ecde011c/odoo/models.py#L5234-L5236

**Customer Case:**
A custom field was renamed, but it old name was still there in the ordering of `ir.model`. As a result, when
`_order_field_to_sql` was triggered, it attempted to get the field using the `old name`. This led to a failure and blocked the request due to the outdated field reference.

https://github.com/odoo/upgrade/blob/bf0fa8e574702a48a79b39ac6f0bc4d7a4cbb0eb/migrations/base/0.0.0/pre-models-custom-field-name.py#L33

**Traceback:**
```sql
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 5240, in _order_field_to_sql
    raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
ValueError: Invalid field 'sequence' on model 'ir.actions.report.substitution.rule'
```

**Regex Matchs:**
![image](https://github.com/user-attachments/assets/800a44c9-6e45-4936-8a8d-12a9eecd2603)


UPG: 2733312
OPW: 4643260