### PR TITLE
[FIX] util/domains: ast.Constant doesn't exist in Python2

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -102,7 +102,13 @@ except ImportError:
     del expression  # unset so it's not used directly
 
 
-AST_CONSTANT_TYPES = (ast.Constant, ast.Str) if sys.version_info < (3, 12) else (ast.Constant,)
+AST_CONSTANT_TYPES = (
+    (ast.Str,)
+    if sys.version_info < (3, 0)
+    else (ast.Constant, ast.Str)
+    if sys.version_info < (3, 12)
+    else (ast.Constant,)
+)
 
 _logger = logging.getLogger(__name__)
 DomainField = collections.namedtuple("DomainField", "table domain_column model_select")


### PR DESCRIPTION
Exaple error:
```
2025-04-18 16:00:25,979 531760 ERROR test_9_10 odoo.modules.migration: module base: Each pre-migration file must have a "migrate(cr, installed_version)" function
```

The problem is that the AttributeError in Odoo 10 hides the real issue:
```
'module' object has no attribute 'Constant'
```
See:
https://github.com/odoo/odoo/blob/28c3f51c4878fbcd79b2e819948465fcf2160ebc/odoo/modules/migration.py#L166-L167
