### PR TITLE
[IMP] adapt code to new simplified `safe_eval` API

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -17,7 +17,6 @@ except ImportError:
 
 from odoo import modules
 from odoo.tools import mute_logger
-from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.base.maintenance.migrations import util
 from odoo.addons.base.maintenance.migrations.testing import UnitTestCase, parametrize
@@ -1735,11 +1734,11 @@ class TestMisc(UnitTestCase):
         ]
     )
     def test_SelfPrint(self, value, expected):
-        evaluated = safe_eval(value, util.SelfPrintEvalContext(), nocopy=True)
+        evaluated = util.safe_eval(value, util.SelfPrintEvalContext())
         self.assertEqual(str(evaluated), expected, "Self printed result differs")
 
         replaced_value, ctx = util.SelfPrintEvalContext.preprocess(value)
-        evaluated = safe_eval(replaced_value, ctx, nocopy=True)
+        evaluated = util.safe_eval(replaced_value, ctx)
         self.assertEqual(str(evaluated), expected, "Prepared self printed result differs")
 
     @parametrize(
@@ -1759,7 +1758,7 @@ class TestMisc(UnitTestCase):
     @unittest.skipUnless(util.ast_unparse is not None, "`ast.unparse` available from Python3.9")
     def test_SelfPrint_prepare(self, value, expected):
         replaced_value, ctx = util.SelfPrintEvalContext.preprocess(value)
-        evaluated = safe_eval(replaced_value, ctx, nocopy=True)
+        evaluated = util.safe_eval(replaced_value, ctx)
         # extra fallback for old unparse from astunparse package
         self.assertIn(str(evaluated), [expected, "({})".format(expected)])
 
@@ -1776,7 +1775,7 @@ class TestMisc(UnitTestCase):
     def test_SelfPrint_failure(self, value):
         # note: `safe_eval` will re-raise a ValueError
         with self.assertRaises(ValueError):
-            safe_eval(value, util.SelfPrintEvalContext(), nocopy=True)
+            util.safe_eval(value)
 
     @parametrize(
         [

--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -28,15 +28,13 @@ except ImportError:
 
 try:
     from odoo.tools import exception_to_unicode
-    from odoo.tools.safe_eval import safe_eval
 except ImportError:
     from openerp.tools import exception_to_unicode
-    from openerp.tools.safe_eval import safe_eval
 
 from .const import NEARLYWARN
 from .helpers import _dashboard_actions, _validate_model, resolve_model_fields_path
 from .inherit import for_each_inherit
-from .misc import SelfPrintEvalContext, ast_unparse, literal_replace, version_gte
+from .misc import SelfPrintEvalContext, ast_unparse, literal_replace, safe_eval, version_gte
 from .pg import column_exists, get_value_or_en_translation, table_exists
 from .records import edit_view
 
@@ -300,7 +298,7 @@ def _adapt_one_domain_old(cr, target_model, old, new, model, domain, adapter=Non
     if isinstance(domain, basestring):
         try:
             replaced_domain, ctx = SelfPrintEvalContext.preprocess(domain)
-            eval_dom = normalize_domain(safe_eval(replaced_domain, ctx, nocopy=True))
+            eval_dom = normalize_domain(safe_eval(replaced_domain, ctx))
         except Exception as e:
             oops = exception_to_unicode(e)
             _logger.log(NEARLYWARN, "Cannot evaluate %r domain: %r: %s", model, domain, oops)


### PR DESCRIPTION
`safe_eval` loose the `nocopy` option. As we rely on it when evaluating expression, we need to reimplement `safe_eval` to do the evaluation using the `SelfPrintEvalContext`.

See odoo/odoo#206846
See odoo/enterprise#83818