### PR TITLE
[FIX] util/pg: Fix escaping issue

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -2109,13 +2109,13 @@ class TestConvertFieldToHtml(UnitTestCase):
         f1 = self.env["ir.model.fields"].create(
             {"name": "x_testx", "model": "res.partner", "ttype": "text", "model_id": model.id, "translate": True}
         )
-        partner = self.env["res.partner"].create({"name": "test Pxtner", "x_testx": "test partner field"})
-        default = self.env["ir.default"].create({"field_id": f1.id, "json_value": '"Test text"'})
+        partner = self.env["res.partner"].create({"name": "test Pxtner", "x_testx": "test\npartner field"})
+        default = self.env["ir.default"].create({"field_id": f1.id, "json_value": '"Test\\ntext"'})
         util.convert_field_to_html(cr, "res.partner", "x_testx")
         util.invalidate(default)
 
-        self.assertEqual(default.json_value, '"<p>Test text</p>"')
-        self.assertEqual(partner.x_testx, "<p>test partner field</p>")
+        self.assertEqual(default.json_value, '"<p>Test<br>text</p>"')
+        self.assertEqual(partner.x_testx, "<p>test<br>partner field</p>")
 
 
 class TestRemoveView(UnitTestCase):

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -698,10 +698,10 @@ def convert_field_to_html(cr, model, field, skip_inherit=()):
 
     # Update ir.default
     if table_exists(cr, "ir_default"):
-        json_value_html = pg_text2html("json_value::json #>> '{}'")
+        json_value_html = pg_text2html("json_value::jsonb->>0")
         query = """
                 UPDATE ir_default AS d
-                   SET json_value = to_json(({})::text)::text
+                   SET json_value = to_json({})::text
                   FROM ir_model_fields AS imf
                  WHERE imf.name = %s
                    AND imf.model = %s

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -428,9 +428,9 @@ def pg_text2html(s, wrap="p"):
                                            'https?://[-A-Za-z0-9+&@#/%%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%%=~_()|]',
                                            '<a href="\&" target="_blank" rel="noreferrer noopener">\&</a>',
                                            'g'),
-                            E'\\n',
+                            E'\n',
                             '<br>'),
-                    E'\\t',
+                    E'\t',
                     '&Tab;'),
                 '{closing_tag}')
          END


### PR DESCRIPTION
due to this escaping issue ``\n`` never converted
to ``<br>`` so fixing it. as per psql documentation 
https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE

before fix:
```sql
website_crm=> select description from crm_lead where id=25;
 description
-------------
 test       +
 test       +
 etest      +

(1 row)

website_crm=> \q
```
after fix:

```sql
website_crm_18.0=> select description from crm_lead where id=25;
           description
----------------------------------
 <p>test<br>test<br>etest<br></p>
(1 row)
```
upg-2709886
opw-4781422