### PR TITLE
[FIX] util/models: Fix UpgradeError

### DIFF
--- a/src/base/0.0.0/end-moved0.py
+++ b/src/base/0.0.0/end-moved0.py
@@ -11,9 +11,8 @@ def migrate(cr, version):
 
     cr.execute("SELECT value FROM upgrade_test_data WHERE key = %s", [pre.KEY])
     expected = [tuple(i) for i in cr.fetchone()[0]] if cr.rowcount else []
-    value = pre.get_moved0_columns(cr)
-    if value != expected:
-        moved_fields = set(value) - set(expected)
+    moved_fields = set(pre.get_moved0_columns(cr)) - set(expected)
+    if moved_fields:
         raise util.UpgradeError(
             "New `moved0` field. It happen when the ORM cannot change a column type by itself.\n%s"
             % "\n".join("\t- %s.%s" % m for m in sorted(moved_fields))


### PR DESCRIPTION
if model is remove but related to that data is still in  ``upgrade_test_data`` so it failing
because here in [``expected``]( https://github.com/odoo/upgrade-util/blob/e6f36d0d5f3c42453876b046d3d6a2ba39403a40/src/base/0.0.0/end-moved0.py#L13) getting the records of that model which is removed and in ``value`` we are not getting values of which model is removed that is why below mentioned traceback is rasied for fixing it cleaning up the data from value in ``upgrade_test_data``

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/11.0/odoo/service/server.py", line 1054, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/11.0/odoo/modules/registry.py", line 85, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/11.0/odoo/modules/loading.py", line 391, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/11.0/odoo/modules/migration.py", line 202, in migrate_module
    migrate(self.cr, installed_version)
  File "/home/odoo/src/odoo/11.0/odoo/addons/base/maintenance/migrations/base/0.0.0/end-moved0.py", line 19, in migrate
    % "\n".join("\t- %s.%s" % m for m in sorted(moved_fields))
odoo.addons.base.maintenance.migrations.util.exceptions.UpgradeError: New `moved0` field. It happen when the ORM cannot change a column type by itself.
```

upg-2797343
opw-4800416