### PR TITLE
[IMP] pg: tiny simplification

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -111,9 +111,7 @@ if ThreadPoolExecutor is not None:
         def execute(query):
             with cursor() as tcr:
                 tcr.execute(query)
-                cnt = tcr.rowcount
-                tcr.commit()
-                return cnt
+                return tcr.rowcount
 
         cr.commit()
 


### PR DESCRIPTION
When using a `Cursor` in a `with` statement, it will be committed automatically. No need to do it explicitly and no need to save the rowcount in a local var.