### PR TITLE
[FIX] modules: avoid conflicts on ir_model_data in new_module

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -841,8 +841,12 @@ def new_module(cr, module, deps=(), auto_install=False, category=None, countries
             """
             INSERT INTO ir_model_data (name, module, noupdate, model, res_id)
                  VALUES ('module_'||%s, 'base', 't', 'ir.module.module', %s)
+            ON CONFLICT (module, name)
+          DO UPDATE SET noupdate = 't',
+                        model = 'ir.module.module',
+                        res_id = %s
             """,
-            [module, new_id],
+            [module, new_id, new_id],
         )
 
     for dep in deps:


### PR DESCRIPTION
There is a condition for the ir_module_module to exist, but it is possible that while the module doesn't exist, the ir_model_data for this (module, name) do in fact exists, which leads to the unique key failing when attepting to insert these values again.

This was detected when upgrading from 11.0 to 18.0 in one run.