### PR TITLE
[FIX] util/records:Mark records noupdate

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1092,6 +1092,12 @@ class TestInherit(UnitTestCase):
         self.assertTrue(all(inh.model == "product.product" for inh in inhs))
         self.assertEqual([inh.via for inh in inhs], [None, None, "product_tmpl_id"])
 
+    def test_inherits_parents(self):
+        self.assertEqual(
+            list(util.inherits_parents(self.env.cr, "crm.team")),
+            [("mail.alias", "alias_id")],
+        )
+
 
 class TestNamedCursors(UnitTestCase):
     @staticmethod

--- a/src/util/inherit.py
+++ b/src/util/inherit.py
@@ -95,7 +95,7 @@ def for_each_inherit(cr, model, skip=(), interval="[)"):
 
 
 def direct_inherit_parents(cr, model, skip=(), interval="[)"):
-    """Yield the *direct* inherits parents."""
+    """Yield the *direct* inherit parents."""
     if skip == "*":
         return
     skip = set(skip)
@@ -122,3 +122,19 @@ def inherit_parents(cr, model, skip=(), interval="[)"):
         for grand_parent in inherit_parents(cr, parent, skip=skip, interval=interval):
             yield grand_parent
             skip.add(grand_parent)
+
+
+def inherits_parents(cr, model, skip=(), interval="[)"):
+    """Yield the inherit*s* parents."""
+    if skip == "*":
+        return
+    skip = set(skip)
+
+    for parent, inh in direct_inherit_parents(cr, model, skip, interval):
+        if inh.via:
+            yield parent, inh.via
+            skip.add(parent)
+        else:
+            for grand_parent, fieldname in inherits_parents(cr, parent, skip, interval):
+                yield grand_parent, fieldname
+                skip.add(grand_parent)

--- a/src/util/inherit.py
+++ b/src/util/inherit.py
@@ -121,3 +121,4 @@ def inherit_parents(cr, model, skip=(), interval="[)"):
         skip.add(parent)
         for grand_parent in inherit_parents(cr, parent, skip=skip, interval=interval):
             yield grand_parent
+            skip.add(grand_parent)

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1107,7 +1107,8 @@ def __update_record_from_xml(
         return
     else:
         # The xmlid doesn't already exists, nothing to reset
-        reset_write_metadata = noupdate = reset_translations = False
+        reset_write_metadata = reset_translations = False
+        noupdate = True
         fields = None
 
     write_data = None

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -33,7 +33,7 @@ from .helpers import (
 )
 from .inconsistencies import break_recursive_loops
 from .indirect_references import indirect_references
-from .inherit import direct_inherit_parents, for_each_inherit
+from .inherit import for_each_inherit, inherits_parents
 from .misc import Sentinel, chunks, parse_version, version_gte
 from .orm import env, flush
 from .pg import (
@@ -841,16 +841,15 @@ def rename_xmlid(cr, old, new, noupdate=None, on_collision="fail"):
             """
             cr.execute(query, {"old": r"\y{}\y".format(re.escape(old)), "new": new})
 
-        for parent_model, inh in direct_inherit_parents(cr, model):
-            if inh.via:
-                parent = parent_model.replace(".", "_")
-                rename_xmlid(
-                    cr,
-                    "{}_{}".format(old, parent),
-                    "{}_{}".format(new, parent),
-                    noupdate=noupdate,
-                    on_collision=on_collision,
-                )
+        for parent_model, _ in inherits_parents(cr, model):
+            parent = parent_model.replace(".", "_")
+            rename_xmlid(
+                cr,
+                "{}_{}".format(old, parent),
+                "{}_{}".format(new, parent),
+                noupdate=noupdate,
+                on_collision=on_collision,
+            )
         return new_id
     return None
 

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1096,13 +1096,10 @@ def __update_record_from_xml(
 
     cr.execute(
         """
-        UPDATE ir_model_data d
-           SET noupdate = false
-          FROM ir_model_data o
-         WHERE o.id = d.id
-           AND d.module = %s
-           AND d.name = %s
-     RETURNING d.model, d.res_id, o.noupdate
+        SELECT model, res_id, noupdate
+          FROM ir_model_data
+         WHERE module = %s
+           AND name = %s
     """,
         [module, name],
     )
@@ -1110,6 +1107,7 @@ def __update_record_from_xml(
         model, res_id, noupdate = cr.fetchone()
         if model == "ir.model":
             return
+        force_noupdate(cr, xmlid, noupdate=False)
     elif not force_create:
         _logger.warning("Record %r not found in database. Skip update.", xmlid)
         return


### PR DESCRIPTION
If particular xml don't have noupdate marked but parent ``data`` node have noupdate in that case from update_records_from_xml creating record as noupdate ``false`` which is causing issue in future upgrade because it going for delete. For preventing such case adding noupdate flag to record and inherit created record acccoring to this [commit](
https://github.com/odoo/odoo/commit/ef709fd92b7b22a58e60715c9ff7ab4476a83ca5#diff-7144f88ea32f36feb17ce1b8dda7dee1631f5ada34075414587df3948c6b3d1bL4098-R4118) by that ``//data`` node or that ``xml node``  itself.

use case:
client db don't have the [``documents.document_internal_folder``](https://github.com/odoo/enterprise/blob/6c677f388c934e3fc545fc7cb2f9d65a958433da/documents/data/documents_document_data.xml#L2-L18) xmlid which is created when migrated to 18.0 from this [script](
https://github.com/odoo/upgrade/blob/9327a2c12d9faf67d71f09bbe4d91e6105c75dca/migrations/documents/saas~17.5.1.4/post-migrate.py#L24) with noupdate false and because data node have noupdate true but particular xml don't have noupdate that is why it created as noupdate false and other inherit records also with noupdate and after migrating from onwards version related to that mail.alias records xml creating according to [this](
https://github.com/odoo/odoo/blob/9822f5cd1fd3ac60689fc5e3101e5f6fa6a5722d/odoo/models.py#L5514)

and later on version in 18.3 if related inherit model is changed but still some how use case of those records for preventing in that case.

before upgrade
```
timer_test_document_test=# select * from ir_model_data where name like '%document_internal_folder%'
;
 id | create_uid | create_date | write_date | write_uid | res_id | noupdate | name | module | model
----+------------+-------------+------------+-----------+--------+----------+------+--------+-------
(0 rows)
```

before fix
```
timer_test_document_test=# select * from ir_model_data where name like '%document_internal_folder%'
;
  id   | create_uid |        create_date         |         write_date         | write_uid | res_id | noupdate |                name                 |  module   |       model
-------+------------+----------------------------+----------------------------+-----------+--------+----------+-------------------------------------+-----------+--------------------
 39576 |            | 2025-06-19 13:38:37.987267 | 2025-06-19 13:38:37.987267 |           |     20 | f        | document_internal_folder_mail_alias | documents | mail.alias
 39577 |            | 2025-06-19 13:38:37.987267 | 2025-06-19 13:38:37.987267 |           |     20 | f        | document_internal_folder            | documents | documents.document
```

after fix
```
timer_test_document_test=# select * from ir_model_data where name like '%document_internal_folder%'
;
  id   | create_uid |        create_date         |         write_date         | write_uid | res_id | noupdate |                name                 |  module   |       model
-------+------------+----------------------------+----------------------------+-----------+--------+----------+-------------------------------------+-----------+--------------------
 39576 |            | 2025-06-19 13:41:40.343454 | 2025-06-19 13:41:40.343454 |           |     20 | t        | document_internal_folder_mail_alias | documents | mail.alias
 39577 |            | 2025-06-19 13:41:40.343454 | 2025-06-19 13:41:40.343454 |           |     20 | t        | document_internal_folder            | documents | documents.document

```

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.3/odoo/service/server.py", line 1396, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/odoo/src/odoo/saas-18.3/odoo/tools/func.py", line 83, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/registry.py", line 167, in new
    load_modules(
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/loading.py", line 509, in load_modules
    env['ir.model.data']._process_end(registry.updated_modules)
  File "/tmp/tmp2ipekce9/migrations/base/0.0.0/pre-models-no-model-data-delete.py", line 108, in _process_end
    return super(IrModelData, self)._process_end(modules)
  File "/home/odoo/src/odoo/saas-18.3/odoo/addons/base/models/ir_model.py", line 2589, in _process_end
    self._process_end_unlink_record(record)
  File "/home/odoo/src/odoo/saas-18.3/addons/website/models/ir_model_data.py", line 35, in _process_end_unlink_record
    return super()._process_end_unlink_record(record)
  File "/home/odoo/src/odoo/saas-18.3/odoo/addons/base/models/ir_model.py", line 2518, in _process_end_unlink_record
    record.unlink()
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/models.py", line 3913, in unlink
    cr.execute(SQL(
  File "/home/odoo/src/odoo/saas-18.3/odoo/sql_db.py", line 422, in execute
    self._obj.execute(query, params)
psycopg2.errors.ForeignKeyViolation: update or delete on table "mail_alias" violates foreign key constraint "documents_document_alias_id_fkey" on table "documents_document"
DETAIL:  Key (id)=(40) is still referenced from table "documents_document".
```

upg-2987024
opw-4874805