### PR TITLE
[IMP] jinja_to_qweb: avoid MemoryError

### DIFF
--- a/src/util/jinja_to_qweb.py
+++ b/src/util/jinja_to_qweb.py
@@ -3,6 +3,7 @@ import functools
 import html
 import logging
 import re
+from multiprocessing import Process, Queue
 
 import babel
 import lxml
@@ -486,35 +487,46 @@ def verify_upgraded_jinja_fields(cr):
                 "Jinja upgrade",
                 format="html",
             )
+    # done with the global data, clear it for the rest of the upgrade
+    templates_to_check.clear()
 
 
 def is_converted_template_valid(env, template_before, template_after, model_name, record_id, engine="inline_template"):
-    render_before = None
-    with contextlib.suppress(Exception):
-        render_before = _render_template_jinja(env, template_before, model_name, record_id)
+    def callback(q):
+        render_before = None
+        with contextlib.suppress(Exception):
+            render_before = _render_template_jinja(env, template_before, model_name, record_id)
 
-    render_after = None
-    if render_before is not None:
-        try:
-            with mute_logger("odoo.addons.mail.models.mail_render_mixin"):
-                render_after = env["mail.render.mixin"]._render_template(
-                    template_after, model_name, [record_id], engine=engine
-                )[record_id]
-        except Exception:
-            pass
+        render_after = None
+        if render_before is not None:
+            try:
+                with mute_logger("odoo.addons.mail.models.mail_render_mixin"):
+                    render_after = env["mail.render.mixin"]._render_template(
+                        template_after, model_name, [record_id], engine=engine
+                    )[record_id]
+            except Exception:
+                pass
 
-    # post process qweb render to remove comments from the rendered jinja in
-    # order to avoid false negative because qweb never render comments.
-    if render_before and render_after and engine == "qweb":
-        element_before = lxml.html.fragment_fromstring(render_before, create_parent="div")
-        for comment_element in element_before.xpath("//comment()"):
-            comment_element.getparent().remove(comment_element)
+        # post process qweb render to remove comments from the rendered jinja in
+        # order to avoid false negative because qweb never render comments.
+        if render_before and render_after and engine == "qweb":
+            element_before = lxml.html.fragment_fromstring(render_before, create_parent="div")
+            for comment_element in element_before.xpath("//comment()"):
+                comment_element.getparent().remove(comment_element)
         render_before = lxml.html.tostring(element_before, encoding="unicode")
         render_after = lxml.html.tostring(
             lxml.html.fragment_fromstring(render_after, create_parent="div"), encoding="unicode"
         )
 
-    return render_before is not None and render_before == render_after
+        q.put(render_before is not None and render_before == render_after)
+
+    queue = Queue()
+    proc = Process(target=callback, args=((queue,)))
+    proc.start()
+    res = queue.get(timeout=60)
+    if proc.is_alive():
+        proc.kill()
+    return res
 
 
 # jinja render


### PR DESCRIPTION
upg-2994884

Avoid `MemoryError` and/or killed process because of `malloc()` failing within `lxml` / `libxml2`.

Debugging this by determining the size of involved datastructures through means of `sys.getsizeof()` showed that:
1. The global variable `templates_to_check` grows to roughly 1.4GiB after the various calls to `upgrade_jinja_fields()` by upgrade scripts. The process uses ~1.5GiB at that point
2. At the start of function `verify_upgraded_jinja_fields()`, the process is still at ~1.5GiB. While iterating over all the templates in `templates_to_check`, no significant amount of memory is allocated on top of this *to python datastructures*. But, with each call to `is_converted_template_valid()`, the size of the process increases until it hits the RLIMIT. This function calls into `lxml` multiple times, suggesting that the memory is allocated in `malloc()` calls in the C library, evading python's accounting. Internet research shows that `lxml` has a long history of different memory leaks in C code, plus some caching mechanism *across documents* that could be responsible[^1]. More recent versions of the module seem to have been improved, but still we're stuck with old versions.

This patch solves / works around (2) by running the function body of `is_converted_template_valid()` in a forked subprocess that is killed immediately after (instead of using a process pool) and thus no additional memory is ever allocated by `lxml` in the main process, its memory use stays at ~1.5GiB during the runtime of `verify_upgraded_jinja_fields()`. We also add a final line to that function that clears the global data when it is processed, at which point the processes memory use drops to 100MiB.

This patch does *not* solve (1). Solving (2) is enough to fully process upg-2994884, but a future upgrade request may require a fix for (1), too. This will probably be a bigger patch, because I think a viable solution for this would mean to remove the global `templates_to_check` and instead store tha data in the database.

[^1]: https://benbernardblog.com/tracking-down-a-freaky-python-memory-leak-part-2/