### PR TITLE
[IMP] get_module_path: remove downloaded

### DIFF
--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -130,7 +130,8 @@ def has_enterprise():
     if os.getenv("ODOO_HAS_ENTERPRISE"):
         return True
     # XXX maybe we will need to change this for version > 9
-    return bool(get_module_path("delivery_fedex", downloaded=False, display_warning=False))
+    kw = {} if version_gte("saas~18.5") else {"downloaded": False}
+    return bool(get_module_path("delivery_fedex", display_warning=False, **kw))
 
 
 @_cached
@@ -142,7 +143,8 @@ def has_design_themes():
     """
     if os.getenv("ODOO_HAS_DESIGN_THEMES"):
         return True
-    return bool(get_module_path("theme_yes", downloaded=False, display_warning=False))
+    kw = {} if version_gte("saas~18.5") else {"downloaded": False}
+    return bool(get_module_path("theme_yes", display_warning=False, **kw))
 
 
 @_cached


### PR DESCRIPTION
tools.config.addons_data_dir is already in odoo.addons.__path__, the parameter ``downloaded`` is not necessary and removed since saas-18.5.

https://github.com/odoo/odoo/pull/217924