### PR TITLE
[IMP] base: store explict field.translate

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1219,8 +1219,12 @@ def __update_record_from_xml(
                     fields_with_values_from_xml |= {"arch_db", "name"}
             else:
                 fields_with_values_from_xml = fields
+            if version_gte("saas~18.5"):  # translate is varchar
+                sql_code = "SELECT name FROM ir_model_fields WHERE model = %s AND translate IS NOT NULL AND name IN %s"
+            else:  # translate is boolean
+                sql_code = "SELECT name FROM ir_model_fields WHERE model = %s AND translate = true AND name IN %s"
             cr.execute(
-                "SELECT name FROM ir_model_fields WHERE model = %s AND translate = true AND name IN %s",
+                sql_code,
                 [model, tuple(fields_with_values_from_xml)],
             )
             reset_translations = [fname for [fname] in cr.fetchall()]


### PR DESCRIPTION
before this commit:
| field.translate in orm | ir_model_fields.translate in database |
| ---------------------- | ------------------------------------- |
| False                  | False                                 |
| True                   | True                                  |
| html_translate         | True                                  |
| xml_translate          | True                                  |

after this commit:
| field.translate in orm | ir_model_fields.translate in database |
| ---------------------- | ------------------------------------- |
| False                  | NULL                                  |
| True                   | 'standard'                            |
| html_translate         | 'html_translate'                      |
| xml_translate          | 'xml_translate'                       |

https://github.com/odoo/odoo/pull/219406
https://github.com/odoo/enterprise/pull/90413
https://github.com/odoo/upgrade/pull/8085
