### PR TITLE
[FIX] util/misc: `split_osenv`, do not return `[""]`

### DIFF
--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -189,7 +189,8 @@ def expand_braces(s):
 
 
 def split_osenv(name, default=""):
-    return re.split(r"\W+", os.getenv(name, default).strip())
+    value = os.getenv(name, default).strip()
+    return re.split(r"\W+", value) if value else []
 
 
 try:


### PR DESCRIPTION
If the env var was not set we returned `[""]`. That was confusing.
It also breaks the boolean check of the result.

With this patch we just return an empty list when the variable is not set.

See also: odoo/upgrade#8174

Co-Authored-By: Christophe Simonis (chs) <chs@odoo.com>
