### PR TITLE
[FIX] util.merge_module: remove old COW views

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -478,8 +478,8 @@ def merge_module(cr, old, into, update_dependers=True):
 
     _up("constraint", mod_ids[old], mod_ids[into])
     _up("relation", mod_ids[old], mod_ids[into])
-    _update_view_key(cr, old, into)
     _up("data", old, into)
+    _update_view_key(cr, old, into)
     if table_exists(cr, "ir_translation"):
         cr.execute("UPDATE ir_translation SET module=%s WHERE module=%s", [into, old])
 


### PR DESCRIPTION
When a module is merged, all views xmlids are moved to the new module and any duplicated are removed, keeping the new module view per xmlid.
When website is also installed, views would also have COWed copies that have no xmlids, but share the same key. If we update the key for the COW views before renaming the original view's xmlids, the COW views would still be in the db after the removal of the view that is no longer valid, causing issues post upgrades. But if we rename the xmlids first, then unwanted COW views will be removed, and the wanted ones will remain, and then renaming the keys will make sure the wanted ones are correctly associated with the new module.

opw-4968153
upg-3018282