### PR TITLE
[IMP] create_m2m: auto generate and return table name

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1045,6 +1045,18 @@ class TestPG(UnitTestCase):
         self.assertTrue(s(ulc.using(alias="x")), ', "x"."a", "x"."A"')
         self.assertIs(ulc, ulc.using(leading_comma=True))
 
+    def test_create_m2m(self):
+        cr = self.env.cr
+
+        m2m_name = "random_table_name"
+        created_m2m = util.create_m2m(cr, m2m_name, "res_users", "res_groups")
+        self.assertEqual(m2m_name, created_m2m)
+        self.assertTrue(util.table_exists(cr, created_m2m))
+
+        auto_generated_m2m_table_name = util.create_m2m(cr, util.AUTO, "res_users", "res_groups")
+        self.assertEqual("res_groups_res_users_rel", auto_generated_m2m_table_name)
+        self.assertTrue(util.table_exists(cr, auto_generated_m2m_table_name))
+
 
 class TestORM(UnitTestCase):
     def test_create_cron(self):

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -44,7 +44,7 @@ from .domains import _adapt_one_domain, _replace_path, _valid_path_to, adapt_dom
 from .exceptions import SleepyDeveloperError
 from .helpers import _dashboard_actions, _validate_model, resolve_model_fields_path, table_of_model
 from .inherit import for_each_inherit
-from .misc import log_progress, safe_eval, version_gte
+from .misc import AUTO, log_progress, safe_eval, version_gte
 from .orm import env, invalidate
 from .pg import (
     SQLStr,
@@ -756,15 +756,12 @@ def convert_m2o_field_to_m2m(cr, model, field, new_name=None, m2m_table=None, co
     table1 = table_of_model(cr, model)
     table2, _, _ = target_of(cr, table1, field)
 
-    if m2m_table is None:
-        m2m_table = "{}_{}_rel".format(*sorted([table1, table2]))
-
     if col1 is None:
         col1 = "{}_id".format(table1)
     if col2 is None:
         col2 = "{}_id".format(table2)
 
-    create_m2m(cr, m2m_table, table1, table2, col1, col2)
+    m2m_table = create_m2m(cr, m2m_table or AUTO, table1, table2, col1, col2)
 
     dedup = SQLStr("ON CONFLICT DO NOTHING")
     if cr._cnx.server_version < 90500:

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -60,6 +60,9 @@ class Sentinel:
         return self.name
 
 
+AUTO = AUTOMATIC = Sentinel("AUTO")
+
+
 def _cached(func):
     sentinel = Sentinel("sentinel")
 

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -1348,7 +1348,8 @@ def create_m2m(cr, m2m, fk1, fk2, col1=None, col2=None):
         fixup_m2m(cr, m2m, fk1, fk2, col1, col2)
         return
 
-    cr.execute(
+    query = format_query(
+        cr,
         """
         CREATE TABLE {m2m}(
             {col1} integer NOT NULL REFERENCES {fk1}(id) ON DELETE CASCADE,
@@ -1356,8 +1357,14 @@ def create_m2m(cr, m2m, fk1, fk2, col1=None, col2=None):
             PRIMARY KEY ({col1}, {col2})
         );
         CREATE INDEX ON {m2m}({col2}, {col1});
-    """.format(**locals())
+        """,
+        m2m=m2m,
+        col1=col1,
+        col2=col2,
+        fk1=fk1,
+        fk2=fk2,
     )
+    cr.execute(query)
 
 
 def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -34,7 +34,7 @@ from .helpers import (
 from .inconsistencies import break_recursive_loops
 from .indirect_references import indirect_references
 from .inherit import direct_inherit_parents, for_each_inherit
-from .misc import Sentinel, chunks, parse_version, version_gte
+from .misc import AUTOMATIC, chunks, parse_version, version_gte
 from .orm import env, flush
 from .pg import (
     PGRegexp,
@@ -1004,9 +1004,6 @@ def ensure_xmlid_match_record(cr, xmlid, model, values):
         )
 
     return new_res_id
-
-
-AUTOMATIC = Sentinel("AUTOMATIC")
 
 
 def update_record_from_xml(


### PR DESCRIPTION
In order to limit chances for typos, while keeping the util backwards compatible (except for the special `m2m` "auto" value), allow users to provide "auto" as a special flag to ask the util to automatically generate the m2m table name, following the same rule as the ORM[^1].

[^1]: Example from 18.0
https://github.com/odoo/odoo/blob/f42fe80576c8b419b5215ff17859e0dfebcd996a/odoo/fields.py#L4918-L4923