### PR TITLE
[FIX] orm: patch manual field names

### DIFF
--- a/src/util/orm.py
+++ b/src/util/orm.py
@@ -726,8 +726,11 @@ def custom_module_field_as_manual(env, rollback=True, do_flush=False):
 
         patches.append(patch.object(BaseModel, "_add_magic_fields", _add_magic_fields))
 
-    if version_gte("saas~16.4"):
-        # 3.5.3 allow loading manual fields
+    # 3.5.3 allow loading manual fields
+    if version_gte("saas~18.4"):
+        patches.append(patch("odoo.fields.is_manual_field_name", lambda name: True))
+        patches.append(patch("odoo.orm.model_classes.is_manual_field_name", lambda name: True))
+    elif version_gte("saas~16.4"):
         patches.append(patch("odoo.addons.base.models.ir_model.IrModelFields._is_manual_name", lambda self, name: True))
 
     with all_patches():


### PR DESCRIPTION
The check for manual field names moved from being a model method to a util function. It needs to be patched starting version `saas~18.4` to allow loading custom module fields as manual for tests during the upgrade process.

Should be merged only after https://github.com/odoo/odoo/pull/224524 and https://github.com/odoo/enterprise/pull/93335