### PR TITLE
[FIX] util/pg: fix rename_model with m2m fields

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -1465,6 +1465,28 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
                 del_action=SQLStr("RESTRICT") if on_delete == "r" else SQLStr("CASCADE"),
             )
             cr.execute(query)
+
+            cr.execute(
+                """
+                UPDATE ir_model_fields
+                   SET column1 = %s
+                 WHERE relation_table = %s
+                   AND column1 = %s
+                   AND state = 'manual'
+                """,
+                [new_col, m2m_table, old_col],
+            )
+            cr.execute(
+                """
+                UPDATE ir_model_fields
+                   SET column2 = %s
+                 WHERE relation_table = %s
+                   AND column2 = %s
+                   AND state = 'manual'
+                """,
+                [new_col, m2m_table, old_col],
+            )
+
             _logger.info("Renamed m2m column of table %s from %s to %s", m2m_table, old_col, new_col)
 
 


### PR DESCRIPTION
In the case of renamed model being referenced in a many2many table (for having or being referenced in a m2m field), related `ir_model_fields.column1` (and 2) aren't updated. However, the m2m tables column names themselves are properly updated. This lead to an error [here](https://github.com/odoo/upgrade/blob/6dd983d2a2682e956c420670a86b277653935faa/migrations/base/0.0.0/pre-fix-fk.py#L17-L22) from [here](https://github.com/odoo/odoo/blob/3b16debc6d6557334082fdf841b20ef0e31fc9d2/odoo/orm/registry.py#L880C17-L880C84) because the `column1` is referring to a column whose name is already overwritten, and to a crash [here](https://github.com/odoo/odoo/blob/3b16debc6d6557334082fdf841b20ef0e31fc9d2/odoo/orm/registry.py#L881) because the returned foreign keys list is empty but accessed at [0]. 

```
2025-09-07 09:59:00,226 27 ERROR db_3124720 odoo.addons.base.maintenance.migrations.base.0.0.0.pre-fix-fk: One of the table/field was missing x_hr_contract_x_employee_deduction_line_e2bef_rel.hr_contract_id / hr_version.id 
2025-09-07 09:59:00,231 27 WARNING db_3124720 odoo.modules.loading: Transient module states were reset 
2025-09-07 09:59:00,231 27 ERROR db_3124720 odoo.registry: Failed to load registry 
2025-09-07 09:59:00,231 27 CRITICAL db_3124720 odoo.service.server: Failed to initialize database `db_3124720`. 
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.4/odoo/service/server.py", line 1410, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/odoo/src/odoo/saas-18.4/odoo/tools/func.py", line 89, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/registry.py", line 175, in new
    load_modules(
  File "/home/odoo/src/odoo/saas-18.4/odoo/modules/loading.py", line 564, in load_modules
    registry.init_models(cr, list(models_to_check), {'models_to_check': True, 'update_custom_fields': True})
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/registry.py", line 742, in init_models
    self.check_foreign_keys(cr)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/registry.py", line 881, in check_foreign_keys
    conname = sql.get_foreign_keys(cr, table1, column1, table2, column2, ondelete)[0]
IndexError: list index out of range
```

```
vval_3124720_indexoutofrange> select id,model,name,state,column1,column2 from ir_model_fields where relation_table = 'x_hr_contract_x_employee_deduction_line_e2bef_rel'
+-------+-------------+--------------------------------+--------+----------------+------------------------------------+
| id    | model       | name                           | state  | column1        | column2                            |
|-------+-------------+--------------------------------+--------+----------------+------------------------------------|
| 12342 | hr.contract | x_studio_many2many_field_Ydvmh | manual | hr_contract_id | x_employee_deduction_line_e2bef_id |
+-------+-------------+--------------------------------+--------+----------------+------------------------------------+
```

[upg-3124720](https://upgrade.odoo.com/odoo/request/3124720)
[tbg](https://upgrade.odoo.com/odoo/tbg/2156)