### PR TITLE
[FIX] util.convert_field_to_translatable

### DIFF
--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -1081,7 +1081,7 @@ if version_gte("16.0"):
     def convert_field_to_translatable(cr, model, field):
         table = table_of_model(cr, model)
         ctype = column_type(cr, table, field)
-        if not ctype or ctype == "json":
+        if not ctype or ctype == "jsonb":
             return
         alter_column_type(cr, table, field, "jsonb", "jsonb_build_object('en_US', {0})")
 


### PR DESCRIPTION
Make the function idempotent.

It was silently break the translations.

```
❯ psql -d test-19 -c 'select name from res_country where id=1;'
┌──────────────────────┐
│         name         │
├──────────────────────┤
│ {"en_US": "Andorra"} │
└──────────────────────┘
(1 row)

Time: 1.353 ms

❯ ./odoo-bin shell --upgrade-path ../../upgrade-util/src -d test-19 --log-handler=:CRITICAL
env: <odoo.orm.environments.Environment object at 0x1134feda0>
odoo: <module 'odoo' (<_frozen_importlib_external._NamespaceLoader object at 0x10e171060>)>
openerp: <module 'odoo' (<_frozen_importlib_external._NamespaceLoader object at 0x10e171060>)>
self: res.users(1,)

In [1]: from odoo.upgrade import util

In [2]: util.convert_field_to_translatable(env.cr, "res.country", "name")

In [3]: env.cr.commit()

In [4]:
Do you really want to exit ([y]/n)? ^D

❯ psql -d test-19 -c 'select name from res_country where id=1;'
┌─────────────────────────────────┐
│              name               │
├─────────────────────────────────┤
│ {"en_US": {"en_US": "Andorra"}} │
└─────────────────────────────────┘
(1 row)

Time: 1.360 ms

❯
```