### PR TITLE
[FIX] pg: rename m2m field meta data

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -45,7 +45,7 @@ except ImportError:
 
 from .exceptions import MigrationError, SleepyDeveloperError
 from .helpers import _validate_table, model_of_table
-from .misc import AUTO, Sentinel, log_progress, on_CI, version_gte
+from .misc import AUTO, Sentinel, get_modules, log_progress, on_CI, version_gte
 
 _logger = logging.getLogger(__name__)
 
@@ -1619,6 +1619,7 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
     if old_table == new_table or not version_gte("10.0"):
         return
     ignored_m2ms = set(ignored_m2ms)
+    standard_modules = set(get_modules()) - {"studio_customization", "__cloc_exclude__"}
     for orig_m2m_table, _, _, other_table in get_m2m_on(cr, new_table):
         if orig_m2m_table in ignored_m2ms:
             continue
@@ -1640,12 +1641,18 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
             rename_table(cr, orig_m2m_table, m2m_table, remove_constraints=False)
             cr.execute(
                 """
-                UPDATE ir_model_fields
+                UPDATE ir_model_fields f
                    SET relation_table = %s
-                 WHERE relation_table = %s
-                   AND state = 'manual'
+                  FROM ir_model_data d
+                 WHERE f.relation_table = %s
+                   AND (
+                       f.state = 'manual'
+                    OR (d.model = 'ir.model.fields'
+                       AND d.res_id = f.id
+                       AND d.module NOT IN %s)
+                       )
                 """,
-                [m2m_table, orig_m2m_table],
+                [m2m_table, orig_m2m_table, tuple(standard_modules)],
             )
             _logger.info("Renamed m2m table %s to %s", orig_m2m_table, m2m_table)
         else:
@@ -1697,23 +1704,35 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
 
             cr.execute(
                 """
-                UPDATE ir_model_fields
+                UPDATE ir_model_fields f
                    SET column1 = %s
-                 WHERE relation_table = %s
-                   AND column1 = %s
-                   AND state = 'manual'
+                  FROM ir_model_data d
+                 WHERE f.relation_table = %s
+                   AND f.column1 = %s
+                   AND (
+                       f.state = 'manual'
+                    OR (d.model = 'ir.model.fields'
+                       AND d.res_id = f.id
+                       AND d.module NOT IN %s)
+                       )
                 """,
-                [new_col, m2m_table, old_col],
+                [new_col, m2m_table, old_col, tuple(standard_modules)],
             )
             cr.execute(
                 """
-                UPDATE ir_model_fields
+                UPDATE ir_model_fields f
                    SET column2 = %s
-                 WHERE relation_table = %s
-                   AND column2 = %s
-                   AND state = 'manual'
+                  FROM ir_model_data d
+                 WHERE f.relation_table = %s
+                   AND f.column2 = %s
+                   AND (
+                       f.state = 'manual'
+                    OR (d.model = 'ir.model.fields'
+                       AND d.res_id = f.id
+                       AND d.module NOT IN %s)
+                       )
                 """,
-                [new_col, m2m_table, old_col],
+                [new_col, m2m_table, old_col, tuple(standard_modules)],
             )
 
             _logger.info("Renamed m2m column of table %s from %s to %s", m2m_table, old_col, new_col)


### PR DESCRIPTION
When renaming a model and updating related m2m fields, the relation table and its columns are renamed but only manual fields meta data is updated, assuming that base fields will be updated when the module loads.
The custom modules meta data should also be updated if the tables were updated.

upg-3176133