### PR TITLE
[ADD] util/report: add new reporting function

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -3064,3 +3064,104 @@ class TestAssertUpdated(UnitTestCase):
         ):
             p2.city = "Niflheim"
             util.flush(p2)
+
+
+class TestReportUtils(UnitTestCase):
+    def test_report_simple(self):
+        self.assertEqual(
+            util.report_with_list(
+                summary="Simple test with minimal arguments and no data.",
+                data=[],
+                columns=("id", "name"),
+                row_format="Partner {name} has id {id}.",
+            ),
+            "<summary>Simple test with minimal arguments and no data.</summary>",
+        )
+
+    def test_report_links(self):
+        self.assertEqual(
+            util.report_with_list(
+                summary="Testing links.",
+                data=[],
+                columns=("id", "name"),
+                row_format="Partner {partner_link}.",
+                links={"partner_link": ("res.partner", "id", "name")},
+            ),
+            "<summary>Testing links.</summary>",
+        )
+
+    def test_report_data_minimal(self):
+        href = (
+            "/odoo/res.partner/1?debug=1"
+            if util.version_gte("18.0")
+            else "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=1"
+        )
+        expected = (
+            "<summary>Test with minimal data.<details><i></i><ul>\n"
+            '<li>Partner <a target="_blank" href="{}">Partner One</a>.</li>\n'
+            "</ul></details></summary>"
+        ).format(href)
+        self.assertEqual(
+            util.report_with_list(
+                summary="Test with minimal data.",
+                data=[(1, "Partner One")],
+                columns=("id", "name"),
+                row_format="Partner {partner_link}.",
+                links={"partner_link": ("res.partner", "id", "name")},
+            ),
+            expected,
+        )
+
+    def test_report_data_limited(self):
+        if util.version_gte("18.0"):
+            href1 = "/odoo/res.partner/1?debug=1"
+            href2 = "/odoo/res.partner/2?debug=1"
+        else:
+            href1 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=1"
+            href2 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=2"
+        expected = (
+            "<summary>Test with limited data.<details><i>The total number of affected records is 3. This list is showing the first 2 records.</i><ul>\n"
+            '<li>Partner <a target="_blank" href="{}">Partner One</a>.</li>\n'
+            '<li>Partner <a target="_blank" href="{}">Partner Two</a>.</li>\n'
+            "</ul></details></summary>"
+        ).format(href1, href2)
+        self.assertEqual(
+            util.report_with_list(
+                summary="Test with limited data.",
+                data=[(1, "Partner One"), (2, "Partner Two"), (3, "Partner Three")],
+                columns=("id", "name"),
+                row_format="Partner {partner_link}.",
+                links={"partner_link": ("res.partner", "id", "name")},
+                total=3,
+                limit=2,
+            ),
+            expected,
+        )
+
+    def test_report_data_limitless(self):
+        if util.version_gte("18.0"):
+            href1 = "/odoo/res.partner/1?debug=1"
+            href2 = "/odoo/res.partner/2?debug=1"
+            href3 = "/odoo/res.partner/3?debug=1"
+        else:
+            href1 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=1"
+            href2 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=2"
+            href3 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=3"
+        expected = (
+            "<summary>Test with limitless data.<details><i></i><ul>\n"
+            '<li>Partner <a target="_blank" href="{}">Partner One</a>.</li>\n'
+            '<li>Partner <a target="_blank" href="{}">Partner Two</a>.</li>\n'
+            '<li>Partner <a target="_blank" href="{}">Partner Three</a>.</li>\n'
+            "</ul></details></summary>"
+        ).format(href1, href2, href3)
+        self.assertEqual(
+            util.report_with_list(
+                summary="Test with limitless data.",
+                data=[(1, "Partner One"), (2, "Partner Two"), (3, "Partner Three")],
+                columns=("id", "name"),
+                row_format="Partner {partner_link}.",
+                links={"partner_link": ("res.partner", "id", "name")},
+                limit=None,
+            ),
+            expected,
+        )

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -73,7 +73,7 @@ from .pg import (
     target_of,
 )
 from .records import _remove_import_export_paths, ref
-from .report import add_to_migration_reports, get_anchor_link_to_record
+from .report import add_to_migration_reports, report_with_list
 
 # python3 shims
 try:
@@ -1598,11 +1598,26 @@ def _update_field_usage_multi(cr, models, old, new, domain_adapter=None, skip_in
                )
     """.format(col_prefix=col_prefix, name=get_value_or_en_translation(cr, "ir_act_server", "name"))
     cr.execute(q, {"old_pattern": p["old_pattern"], "old": p["old"], "standard_modules": tuple(standard_modules)})
-    li = ""
-    if cr.rowcount:
-        li = "".join(
-            "<li>{}</li>".format(get_anchor_link_to_record("ir.actions.server", aid, aname))
-            for aid, aname in cr.fetchall()
+
+    model_text = "All models"
+    if only_models:
+        model_text = "Models " + ", ".join("<kbd>{}</kbd>".format(m) for m in only_models)
+    total = cr.rowcount
+    if total:
+        summary = """
+            {model_text}: the field <kbd>{old}</kbd> has been renamed to <kbd>{new}</kbd>.
+            The following server actions may need an update.
+            If a server action is a standard one and you haven't made any modifications, you may ignore it.
+        """.format(model_text=model_text, old=old, new=new)
+        report_with_list(
+            summary=summary,
+            data=cr.fetchall(),
+            columns=("id", "name"),
+            row_format="{action_link}",
+            links={"action_link": ("ir.actions.server", "id", "name")},
+            total=total,
+            limit=20,
+            category="Fields renamed",
         )
 
     if column_exists(cr, "ir_model_fields", "compute"):
@@ -1621,28 +1636,24 @@ def _update_field_usage_multi(cr, models, old, new, domain_adapter=None, skip_in
                    )
             """
         cr.execute(q, {"old_pattern": p["old_pattern"], "standard_modules": tuple(standard_modules)})
-        if cr.rowcount:
-            li += "".join(
-                "<li>{}</li>".format(get_anchor_link_to_record("ir.model.fields", fid, fname))
-                for fid, fname in cr.fetchall()
+
+        total = cr.rowcount
+        if total:
+            summary = """
+                {model_text}: the field <kbd>{old}</kbd> has been renamed to <kbd>{new}</kbd>.
+                The following compute methods of other fields may need an update.
+                If a field is a standard one and you haven't made any modifications, you may ignore it.
+            """.format(model_text=model_text, old=old, new=new)
+            report_with_list(
+                summary=summary,
+                data=cr.fetchall(),
+                columns=("id", "name"),
+                row_format="{field_link}",
+                links={"field_link": ("ir.model.fields", "id", "name")},
+                total=total,
+                limit=20,
+                category="Fields renamed",
             )
-    if li:
-        model_text = "All models"
-        if only_models:
-            model_text = "Models " + ", ".join("<kbd>{}</kbd>".format(m) for m in only_models)
-        add_to_migration_reports(
-            """
-<details>
-  <summary>
-    {model_text}: the field <kbd>{old}</kbd> has been renamed to <kbd>{new}</kbd>. The following server actions and compute methods of other fields may need an update.
-    If a server action or a field is a standard one and you haven't made any modifications, you may ignore them.
-  </summary>
-  <ul>{li}</ul>
-</details>
-            """.format(**locals()),
-            category="Fields renamed",
-            format="html",
-        )
 
     # if we stay on the same model. (no usage of dotted-path) (only works for domains and related)
     if "." not in old and "." not in new:

--- a/src/util/report.py
+++ b/src/util/report.py
@@ -107,7 +107,7 @@ ODOO_SHOWCASE_VIDEOS = {
 }
 
 
-def add_to_migration_reports(message, category="Other", format="text"):
+def report_message(message, category="Other", format="text"):
     assert format in {"text", "html", "md", "rst"}
     if format == "md":
         message = md2html(dedent(message))
@@ -125,6 +125,91 @@ def add_to_migration_reports(message, category="Other", format="text"):
     )
     if migration_reports_length > 1000000:
         _logger.warning("Upgrade report is growing suspiciously long: %s characters so far.", migration_reports_length)
+
+
+add_to_migration_reports = report_message
+
+
+def report_with_summary(summary, details, category="Other"):
+    """Append the upgrade report with a new entry.
+
+    :param str summary: Description of a report entry.
+    :param str details: Detailed description that is going to be folded by default.
+    :param str category: Title of a report entry.
+    """
+    msg = (
+        "<summary>{}<details>{}</details></summary>".format(summary, details)
+        if details
+        else "<summary>{}</summary>".format(summary)
+    )
+    report_message(message=msg, category=category, format="html")
+    return msg
+
+
+def report_with_list(summary, data, columns, row_format, links=None, total=None, limit=100, category="Other"):
+    """Append the upgrade report with a new entry that displays a list of records.
+
+    The entry consists of a category (title) and a summary (body).
+    The entry displays a list of records previously returned by SQL query, or any list.
+
+    .. example::
+
+        .. code-block:: python
+
+            total = cr.rowcount
+            data = cr.fetchmany(20)
+            util.report_with_list(
+                summary="The following records were altered.",
+                data=data,
+                columns=("id", "name", "city", "comment", "company_id", "company_name"),
+                row_format="Partner with id {partner_link} works at company {company_link} in {city}, ({comment})",
+                links={"company_link": ("res.company", "company_id", "company_name"), "partner_link": ("res.partner", "id", "name")},
+                total=total,
+                category="Accounting"
+            )
+
+    :param str summary: description of a report entry.
+    :param list(tuple) data: data to report, each entry would be a row in the report.
+                             It could be empty, in which case only the summary is rendered.
+    :param tuple(str) columns: columns in `data`, can be referenced in `row_format`.
+    :param str row_format: format for rows, can use any name from `columns` or `links`, e.g.:
+                           "Partner {partner_link} that lives in {city} works at company {company_link}."
+    :param dict(str, tuple(str, str, str)) links: optional model/record links spec,
+                                                  the keys can be referenced in `row_format`.
+    :param int total: optional, total number of records.
+                      Taken as `len(data)` when `None` is passed.
+                      Useful when `data` was limited by the caller.
+    :param int limit: maximum number of records to list in the report.
+                      If `data` contains more records than `limit`, the `total`
+                      number would be included in the report as well.
+                      Set `None` for no limit.
+    :param str category: title of a report entry.
+    """
+
+    def row_to_html(row):
+        raw = dict(zip(columns, row))
+        row_dict = {col: html_escape(str(val)) for col, val in raw.items()}
+        if links:
+            row_dict.update(
+                {
+                    link: get_anchor_link_to_record(rec_model, raw[id_col], raw[name_col])
+                    for link, (rec_model, id_col, name_col) in links.items()
+                }
+            )
+        return "<li>{}</li>".format(row_format.format(**row_dict))
+
+    if not data:
+        row_to_html(columns)  # Validate the format is correct, including links
+        return report_with_summary(summary=summary, details="", category=category)
+
+    disclaimer = "The total number of affected records is {}. ".format(total) if total else ""
+    total = len(data) if total is None else total
+    limit = min(limit, total) if limit is not None else total
+    if total > limit:
+        disclaimer += "This list is showing the first {} records.".format(limit)
+
+    rows = "<ul>\n" + "\n".join([row_to_html(row) for row in data[:limit]]) + "\n</ul>"
+    return report_with_summary(summary, "<i>{}</i>{}".format(disclaimer, rows), category)
 
 
 def announce_release_note(cr):


### PR DESCRIPTION
Add a new function that replaces `util.add_to_migration_reports`.

The new function can automatically parse the provided data as a list of records. It can also limit the number of displayed records to prevent the upgrade report from growing too large.

The structure of the note is now defined within the function itself, standardizing its appearance.

Example usage
===============
More examples will follow in `odoo/upgrade`, replacing the existing use of `util.add_to_migration_reports`.

Example 1
---------------
```
cr.execute(
        """
        SELECT p.id, p.name, p.city, p.comment, p.company_id, com.name FROM res_partner p
          JOIN res_company com
            ON p.company_id = com.id
        """
    )

summary = """
    This is a test of the utility method that is displaying a list of rows
    returned by an SQL query. The number of displayed rows is limited.
    """
row_format = "Partner with id {partner_link} works at company {company_link} in {city}, ({comment})"
columns = ("id", "name", "city", "comment", "company_id", "company_name")
links = {"company_link": ("res.company", "company_id", "company_name"), "partner_link": ("res.partner", "id", "name")}
util.add_report(header="Test of the new utility method", summary=summary, row_format=row_format, columns=columns, links=links, data=cr.fetchall())
```
<img width="1151" height="635" alt="image" src="https://github.com/user-attachments/assets/64542831-f142-484c-becc-ff200297287a" />

Example 2
---------------
```
util.add_report(header="Simple note", summary="A detailed description of the change.")
```
<img width="294" height="75" alt="image" src="https://github.com/user-attachments/assets/aea1c9c6-c7d8-4692-aa82-71ff460e0cdf" />

Example 3
---------------
```
msg = """
This is some text in **bold**.  

This is a line  
that should break.

- Item one
- Item two
    - Sub-item

And some _italic_ text.
"""
util.add_report(header="MD note", summary=msg, report_format="md")
```
<img width="324" height="198" alt="image" src="https://github.com/user-attachments/assets/0c4a9324-cca9-4e4a-834d-ea8ad8d71f63" />


Example 4
---------------
```
msg = """
This is some text in **bold**.

| This is a line
| that should break.

* Item one
* Item two

  * Sub-item

And some *italic* text.
"""
util.add_report(header="RST note", summary=msg, report_format="rst")
```
<img width="411" height="202" alt="image" src="https://github.com/user-attachments/assets/75c92d4e-c1ae-4948-8665-ac4f5c5774ab" />

Remaining details to discuss
===============
1. The introduction of env var to control `limit`.
2. Enforce/assert the use of tuples instead of lists. Currently, it's possible to pass a list for `columns` (instead of a tuple) or a dictionary of lists for `links` (instead of a dictionary of tuples).
3. How to handle depreciation of `add_to_migration_reports`.
4.  Indentation of the `ir.ui.view` record corresponding to the note is sometimes incorrect (previously there was the same issue):
<img width="1527" height="540" alt="image" src="https://github.com/user-attachments/assets/5e9cf10d-2c7f-4898-b842-5bffd1ec231f" />
