### PR TITLE
[IMP] util.update_record_from_xml: set NULL/default values

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1838,7 +1838,7 @@ class TestRecords(UnitTestCase):
         util.flush(usd)
         util.invalidate(usd)
 
-        util.update_record_from_xml(cr, xmlid, fields=("symbol"))
+        util.update_record_from_xml(cr, xmlid, fields=["symbol"])
         util.invalidate(usd)
 
         self.assertEqual(usd.symbol, "$")

--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1844,6 +1844,33 @@ class TestRecords(UnitTestCase):
         self.assertEqual(usd.symbol, "$")
         self.assertEqual(usd.name, "XXX")
 
+    def test_update_record_from_xml__fields_not_in_xml(self):
+        cr = self.env.cr
+        eur_xmlid = "base.EUR"
+
+        eur = self.env.ref(eur_xmlid)
+        eur.write({"position": "before", "rounding": 0.00001})
+        util.flush(eur)
+        util.invalidate(eur)
+
+        util.update_record_from_xml(cr, eur_xmlid, fields=["position", "rounding"])
+        util.invalidate(eur)
+
+        self.assertEqual(eur.position, "after")  # default = "after", not in <record>
+        self.assertEqual(eur.rounding, 0.01)  # default = 0.01, same value in <record>
+
+        pubuser_xmlid = "base.public_user"
+
+        pubuser = self.env.ref(pubuser_xmlid)
+        pubuser.write({"active": True})
+        util.flush(pubuser)
+        util.invalidate(pubuser)
+
+        util.update_record_from_xml(cr, pubuser_xmlid, fields=["active"])
+        util.invalidate(pubuser)
+
+        self.assertFalse(pubuser.active)  # default = True, False in <record>
+
     def test_update_record_from_xml_cache(self):
         cr = self.env.cr
         xmlid = "base.action_attachment"

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1122,7 +1122,8 @@ def update_record_from_xml(
                                    should also be updated.
     :param set(str) or None fields: optional list of fields to include in the XML declaration.
                                     If set, all other fields will be ignored. When set, record
-                                    won't be created if missing.
+                                    won't be created if missing and all fields not found in
+                                    the XML declaration will be set to NULL/their default.
 
     .. warning::
        This functions uses the ORM, therefore it can only be used after **all** models
@@ -1219,6 +1220,7 @@ def __update_record_from_xml(
         elif ref.split(".")[0] == from_module:
             extra_references.append(ref)
 
+    xml_fields = set()
     for f in manifest.get("data", []):
         if not f.endswith(".xml"):
             continue
@@ -1236,6 +1238,8 @@ def __update_record_from_xml(
                     for fn in node.xpath("./field[@name]"):
                         if fn.attrib["name"] not in fields:
                             node.remove(fn)
+                        xml_fields.add(fn.attrib["name"])
+
                 root[0].append(node)
 
                 if node.tag == "menuitem" and parent.tag == "menuitem" and "parent_id" not in node.attrib:
@@ -1266,6 +1270,20 @@ def __update_record_from_xml(
         suffix = " in %r module" % from_module if from_module != module else ""
         raise ValueError("Cannot find %r%s" % (xmlid, suffix))
 
+    new_env = env(cr)
+
+    # override requested fields not found in xml
+    if fields is not None:
+        missing_fields = set(fields) - xml_fields
+        if missing_fields:
+            fields_default = new_env[model].default_get(missing_fields)
+            for field in missing_fields:
+                field_default = fields_default.get(field)
+                if field_default is None:
+                    root[0][-1].append(lxml.builder.E.field(name=field, eval="False"))
+                else:
+                    root[0][-1].append(lxml.builder.E.field(str(field_default), name=field))
+
     done_refs.add(xmlid)
     for ref in extra_references:
         if ref in done_refs:
@@ -1282,8 +1300,6 @@ def __update_record_from_xml(
             fields=None,
             done_refs=done_refs,
         )
-
-    new_env = env(cr)
 
     if version_gte("saas~15.4"):
         new_env.invalidate_all()


### PR DESCRIPTION
Sometimes records get a field removed from their XML declaration. This creates a
divergence between new dbs and upgraded ones. The former will be initialised
with `NULL`/default values, whereas the latter will retain their current one.
This is usually handled in dedicated upgrade scripts with simple queries
un/setting the necessary columns. However, in some cases, these XML changes are
backported/noticed too late and need to be addressed in multiple versions.
That may create the pressure to target future versions, which creates a hidden
coupling between the xml declaration and the query, prone to turn into a bug.
It is one such [example] that inspired this PR.

Here `update_record_from_xml` is adapted to unset fields (or set them to their
default, if any) missing from the xml declaration, if passed explicitely via the
`fields` kwarg. This enables us to leverage the foreward compatibility of
`update_record_from_xml` in the scenario described above, preventing the
associated potential bugs.

[example]: https://github.com/odoo/upgrade/pull/9512

Needs https://github.com/odoo/upgrade/pull/10885