### PR TITLE
[FIX] base: isolate template XML reset from inherited views

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1652,6 +1652,9 @@ class TestRecords(UnitTestCase):
         # reset all fields on a <template>
         template_xmlid = "base.contact_name"
         record = self.env.ref(template_xmlid)
+        children = record.inherit_children_ids.filtered(lambda v: v.active)
+        children.write({"active": False})
+        self.addCleanup(children.write, {"active": True})
         non_xpath = etree.XPath("/non")
         data_after = {"name": "42", "arch_db": "<non>sense</non>"}
         data_before = {key: record[key] for key in data_after}


### PR DESCRIPTION
`test_update_record_from_xml_template_tag` temporarily replaces `base.contact_name` with a dummy `arch_db` to verify `util.update_record_from_xml`.

If active inherited children exist on that template, their inheritance specs no longer apply to the temporary arch, which makes the test fail for an unrelated reason.

task-4328322

See also:
- https://github.com/odoo/odoo/pull/192183
- https://github.com/odoo/enterprise/pull/77155
- https://github.com/odoo/upgrade/pull/8544