### PR TITLE
[FIX] util.version_gte: make sure saas versions are handled in 7.0

### DIFF
--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -24,6 +24,14 @@ except ImportError:
     from openerp.modules.module import get_module_path
     from openerp.tools.parse_version import parse_version
 
+if release.major_version == "7.0":
+    # This version doesn't handle `saas~` part in versions
+    _parse_version = parse_version
+
+    def parse_version(version):
+        return _parse_version(version.replace("saas~", ""))
+
+
 from .exceptions import MigrationError, SleepyDeveloperError
 
 # python3 shim


### PR DESCRIPTION
The `upgrade start` command on the test upgrade platform was failing for
databases in version 7.0. The root cause is that upgrade scripts using
`version_gte("saas~X.Y")` rely on `parse_version` to correctly strip
the "saas~" token when comparing version strings. However, in Odoo 7.0,
`parse_version` does not handle that token, so it leaks into the
returned tuple and breaks the comparison, crashing the upgrade process.

Strip `saas~` from the input of `version_gte` and `version_between`
before handing it to `parse_version`, so that saas version strings are
compared consistently regardless of the running Odoo version.

See: odoo/odoo@a6f724c9196efd323675a7d4ea5a9a8a26157b7b