### PR TITLE
[IMP] util/orm: ensure working of auto-subscribe for upgrade purposes

### DIFF
--- a/src/util/orm.py
+++ b/src/util/orm.py
@@ -108,6 +108,8 @@ def get_admin_channel(cr):
             ]
             if "public" in e[channel_model_name]._fields:
                 search_rules.append(("public", "=", "groups"))
+            if "auto_join" in e[channel_model_name]._fields:
+                search_rules.append(("auto_join", "=", True))
             admin_channel = next(
                 iter(e[channel_model_name].search(search_rules).sorted(lambda c: "admin" not in c.name.lower()) or []),
                 None,
@@ -121,6 +123,8 @@ def get_admin_channel(cr):
                 }
                 if "public" in e[channel_model_name]._fields:
                     channel_values["public"] = "groups"
+                if "auto_join" in e[channel_model_name]._fields:
+                    channel_values["auto_join"] = True
                 admin_channel = e[channel_model_name].create(channel_values)
 
             e["ir.model.data"].create(


### PR DESCRIPTION
At the end of an upgrade, the default '#Administrators' channel is sometimes
used to send upgrade-related information to admins, and a new one is created if
the default one is deleted.

In cases where this new channel is created, the auto-subscribe feature is used
to join admins to the channel. The community counterpart of this commit adds a
boolean that needs to be enabled in order to auto-subscribe users.

The goal of this commit is to ensure that the auto-subscribe of users is
correctly handled in such cases.

community: https://github.com/odoo/odoo/pull/247715
enterprise: https://github.com/odoo/enterprise/pull/117048
upgrade: https://github.com/odoo/upgrade/pull/9436

task-4804991