### PR TITLE
[IMP] util/logger: add `getLogger`

### DIFF
--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -7,7 +7,7 @@ from .fields import *
 from .helpers import *
 from .indirect_references import *
 from .inherit import *
-from .logger import _logger
+from .logger import _logger, getLogger
 from .misc import *
 from .models import *
 from .modules import *

--- a/src/util/logger.py
+++ b/src/util/logger.py
@@ -2,12 +2,40 @@
 import atexit
 import logging
 import os
+import sys
 
 from .misc import on_CI
 
 _REGISTERED = False
 
 _logger = logging.getLogger(__name__.rpartition(".")[0])
+
+
+def getLogger(name=None):
+    """
+    Return a logger named after the caller.
+
+    If `name` is a dotter module, it is used as-is. Otherwise the logger name is taken
+    from the caller's `__name__` when set to a dotted module name (Odoo 16+), or built
+    from the last three components of the caller's file path as
+    `odoo.upgrade.<module>.<version>.<script>`. `<script>` would be `name` parameter if
+    set and non-dotted.
+    """
+    if name and "." in name:
+        return logging.getLogger(name)
+    frame = sys._getframe(1)
+    script = ""
+    if name is None:
+        name = frame.f_globals.get("__name__") or ""
+    else:
+        script = name
+    if "." not in name:
+        path = frame.f_globals.get("__file__") or ""
+        parts = os.path.normpath(path).split(os.sep)
+        module, version, script = parts[-3], parts[-2], script or os.path.splitext(parts[-1])[0]
+        prefix = __name__.rsplit(".", 2)[0]
+        name = ".".join([prefix, module, version, script])
+    return logging.getLogger(name)
 
 
 class CriticalHandler(logging.Handler):

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -249,12 +249,17 @@ try:
                          .. note::
                             The script must be available in the upgrade path.
 
-        :param str or None name: name to assign to the returned module, take the name from
-                                 the imported file if `None`
+        :param str or None name: name to assign to the returned module. When `None`,
+                                 a name is derived from `path` to mirror the name set
+                                 by Odoo (>=16) when loading migration scripts:
+                                 `odoo.upgrade.<module>.<version>.<script>`.
         :return: a module created from the imported upgrade script
         """
         if not name:
-            name, _ = os.path.splitext(os.path.basename(path))
+            parts = os.path.normpath(path).split(os.sep)
+            module, version, script = parts[-3], parts[-2], os.path.splitext(parts[-1])[0]
+            prefix = __name__.rsplit(".", 2)[0]
+            name = ".".join([prefix, module, version, script])
         for full_path in (sp / path for sp in _search_path):
             if full_path.exists():
                 break
@@ -271,10 +276,20 @@ except ImportError:
 
     def import_script(path, name=None):
         if not name:
-            name, _ = os.path.splitext(os.path.basename(path))
-        full_path = os.path.join(os.path.dirname(__file__), "..", path)
+            parts = os.path.normpath(path).split(os.sep)
+            module, version, script = parts[-3], parts[-2], os.path.splitext(parts[-1])[0]
+            prefix = __name__.rsplit(".", 2)[0]
+            name = ".".join([prefix, module, version, script])
+        full_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", path))
+        # In order to avoid `RuntimeWarning: Parent module ... not found` we need to read
+        # the file into a package-less module
+        mod = imp.new_module(name)
+        mod.__file__ = full_path
+        mod.__package__ = ""
+        sys.modules[name] = mod
         with open(full_path) as fp:
-            return imp.load_source(name, full_path, fp)
+            exec(compile(fp.read(), full_path, "exec"), mod.__dict__)
+        return mod
 
 
 @contextmanager


### PR DESCRIPTION
Since Odoo 16 we now have a nice `__name__` for loaded upgrade scripts. For older versions we can still generate one. In this patch we provide a new function to get a "canonical" logger for an upgrade script.

See: https://github.com/odoo/upgrade/pull/10057