### PR TITLE
[IMP] util/records.py: keep m2m_rel table updated by record reference…

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1829,6 +1829,78 @@ def replace_record_references_batch(
                 [model_src, model_dst],
             )
 
+    # m2m fields
+    # in case of differ destination model only
+    if model_src != model_dst:
+        model_src_table = table_of_model(cr, model_src)
+        for foreign_table, foreign_column, conname, _ in get_fk(cr, model_src_table, quote_ident=False):
+            if foreign_table in ignores or foreign_table not in get_m2m_tables(cr, model_src_table):
+                continue
+            # to insert data properly, added later
+            cr.execute("ALTER TABLE {} DROP CONSTRAINT {}".format(foreign_table, conname))
+            (col2,) = get_columns(cr, foreign_table, ignore=(foreign_column,)).iter_unquoted()
+            # handle possible duplicates
+            cr.execute(
+                format_query(
+                    cr,
+                    """
+                    WITH rr2 AS (
+                        SELECT array_agg(t.{fk} ORDER BY t.{fk}) AS olds,
+                                r.new AS new,
+                                t.{col2} AS col2
+                          FROM {table} t
+                          JOIN _upgrade_rrr r
+                            ON r.old = t.{fk}
+                      GROUP BY r.new, t.{col2}
+                    )
+                    DELETE
+                      FROM {table} t
+                     USING rr2 r
+                     WHERE t.{col2} = r.col2
+                       AND t.{fk} = ANY(r.olds)
+                    """,
+                    table=foreign_table,
+                    fk=foreign_column,
+                    col2=col2,
+                )
+            )
+            cr.execute(
+                format_query(
+                    cr,
+                    """
+                    UPDATE {table} t
+                       SET {fk} = r.new
+                      FROM _upgrade_rrr r
+                     WHERE r.old = t.{fk}
+                    """,
+                    table=foreign_table,
+                    fk=foreign_column,
+                )
+            )
+            # cleaning orphan records
+            cr.execute(
+                """
+                DELETE FROM %s t
+                      USING _upgrade_rrr r
+                 RIGHT JOIN %s s
+                         ON r.old = s.id
+                      WHERE r.old IS NULL
+                        AND t.%s = s.id
+                """
+                % (foreign_table, model_src_table, foreign_column)
+            )
+            # updated with same details except new ref table
+            # rest will be updated by `merge_model`
+            cr.execute(
+                format_query(
+                    cr,
+                    "ALTER TABLE {table} ADD FOREIGN KEY ({column}) REFERENCES {dst_table} ON DELETE CASCADE",
+                    table=foreign_table,
+                    column=foreign_column,
+                    dst_table=table_of_model(cr, model_dst),
+                )
+            )
+
     cr.execute("DROP TABLE _upgrade_rrr")
     if parent_field and model_dst == model_src:
         if column_exists(cr, model_src_table, "parent_path"):


### PR DESCRIPTION
… batch

- this function may not include relational table for m2m fields
- tested with respect of: hr/saas~16.5.1.1/pre-migrate.py
  - `hr.plan` to `mail.activity.plan`
  - `hr.plan.activity.type` to `mail.activity.plan.template`

- data in production:
```sql
4165249_16.0=> select count(*) from hr_employee_hr_plan_rel;
 count
-------
    95
(1 row)

4165249_16.0=> select count(*) from hr_employee_hr_plan_activity_type_rel;
 count
-------
   325
(1 row)
```
- Before this PR:
  - relational tables are removed when old model been removed
  - data loss for m2m field
  - logs:
```py
2026-05-12 13:41:20,625 26 INFO 4165249_16.0_17.0 odoo.upgrade.util.models: remove_model('hr.plan.activity.type'): dropping m2m table 'hr_employee_hr_exit_plan_activity_type_rel'
2026-05-12 13:41:20,636 26 INFO 4165249_16.0_17.0 odoo.upgrade.util.models: remove_model('hr.plan.activity.type'): dropping m2m table 'hr_employee_hr_plan_activity_type_rel'
2026-05-12 13:41:23,382 26 INFO 4165249_16.0_17.0 odoo.upgrade.util.models: remove_model('hr.plan'): dropping m2m table 'hr_employee_hr_plan_rel'
2026-05-12 13:41:24,360 26 INFO 4165249_16.0_17.0 odoo.upgrade.util.models: remove_model('hr.plan.wizard'): dropping m2m table 'hr_employee_hr_plan_wizard_rel'
```

- After this PR:
  - relational tables are updated as per new data
  - prevent data loss
  - data:
```sql
4165249_16.0_17.0=> select count(*) from hr_employee_hr_plan_activity_type_rel;
 count
-------
   322
(1 row)

4165249_16.0_17.0=> select count(*) from hr_employee_hr_plan_rel;
 count
-------
    95
(1 row)
```

- OPW-6193389
- UPG-4165249