### PR TITLE
[IMP] util: skip report of removed theme inherited views

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -122,7 +122,19 @@ def remove_view(cr, xml_id=None, view_id=None, silent=False, key=None):
 
     if not view_id:
         return
-
+    theme_view_ids = []
+    if table_exists(cr, "theme_ir_ui_view"):
+        cr.execute(
+            """
+            SELECT array_agg(view.id)
+              FROM theme_ir_ui_view theme
+              JOIN ir_ui_view view
+                ON theme.id = view.theme_template_id
+             WHERE theme.inherit_id = 'ir.ui.view,'|| %s
+            """,
+            [view_id],
+        )
+        theme_view_ids = cr.fetchone()[0] or []
     cr.execute(
         """
         SELECT v.id, x.module || '.' || x.name, v.name
@@ -169,10 +181,11 @@ def remove_view(cr, xml_id=None, view_id=None, silent=False, key=None):
 
             disable_view_query = disable_view_query % extra_set_sql
             cr.execute(disable_view_query, (key or xml_id, child_id))
-            add_to_migration_reports(
-                {"id": child_id, "name": child_name},
-                "Disabled views",
-            )
+            if child_id not in theme_view_ids:
+                add_to_migration_reports(
+                    {"id": child_id, "name": child_name},
+                    "Disabled views",
+                )
     if not silent:
         _logger.info("remove deprecated %s view %s (ID %s)", (key and "COWed") or "built-in", key or xml_id, view_id)
 


### PR DESCRIPTION
**Description:** 

If a website view is deleted, its inherited theme views should not be included in the migration report.

Those views are not archived records that  deleted after the migration. They are deleted as part of the `remove_record()`
cleanup flow, which already explicitly handles  reference records [1].

For theme views, `inherit_id` is a reference field [2] holding the reference to the inherited website view which is ``ir.ui.view``. When the website view is deleted, the related references are removed from `theme_ir_ui_view` during the cleanup process [3]. As a result, those theme views no longer have any valid inherited reference and are deleted afterwards.

Since these records no longer exist at the end of the migration, including them in the migration report provides no useful
information and only adds noise.

**Before fix:**
delete record included in migration report
<img width="1271" height="477" alt="image" src="https://github.com/user-attachments/assets/9003c610-6595-40c6-83a5-e1655ed3e1f2" />

**After fix:**
No migration report is generated for those deleted theme views.
<img width="1503" height="447" alt="image" src="https://github.com/user-attachments/assets/da576622-362b-4499-97bc-ff0c39e5df73" />


[1]: https://github.com/odoo/upgrade-util/blob/73cff78ad078f4f3511d5d4ee1d2a55022ab089f/src/util/records.py#L397-L407
[2]: https://github.com/odoo/odoo/blob/e751fa1e010dbda63903d598048ef415709b4af4/addons/website/models/theme_models.py#L70
[3]: https://github.com/odoo/upgrade-util/blob/73cff78ad078f4f3511d5d4ee1d2a55022ab089f/src/util/records.py#L490-L498

