### PR TITLE
[FIX] util: invalidate stale cache before updating

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1760,6 +1760,28 @@ class TestRecords(UnitTestCase):
         self.assertEqual(usd.symbol, "$")
         self.assertEqual(usd.name, "XXX")
 
+    def test_update_record_from_xml_cache(self):
+        cr = self.env.cr
+        xmlid = "base.action_attachment"
+
+        record_id = util.ref(cr, xmlid)
+        query = "SELECT name FROM ir_act_window WHERE id = %s"
+        if util.column_type(cr, "ir_act_window", "name") == "jsonb":
+            query = "SELECT name->>'en_US' FROM ir_act_window WHERE id = %s"
+
+        cr.execute(query, [record_id])
+        original = cr.fetchone()[0]
+
+        # Load, SQL update, then load shouldn't skip the last load override
+        util.update_record_from_xml(cr, xmlid)
+        cr.execute("""UPDATE ir_act_window SET name = '{"en_US": "hack"}' WHERE id = %s""", [record_id])
+        util.update_record_from_xml(cr, xmlid)
+
+        # Ensure last load restored the value
+
+        cr.execute(query, [record_id])
+        self.assertEqual(cr.fetchone()[0], original)
+
     def test_ensure_xmlid_match_record(self):
         cr = self.env.cr
         tx1 = self.env["res.currency"].create({"name": "TX1", "symbol": "TX1"})

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -1242,7 +1242,16 @@ def __update_record_from_xml(
             done_refs=done_refs,
         )
 
-    cr_or_env = env(cr) if version_gte("saas~16.2") else cr
+    new_env = env(cr)
+
+    if version_gte("saas~15.4"):
+        new_env.invalidate_all()
+    elif version_gte("11.0"):
+        new_env.cache.invalidate()
+    elif version_gte("8.0"):
+        new_env.invalidate_all()
+
+    cr_or_env = new_env if version_gte("saas~16.2") else cr
     parse_kw = {"mode": "update"} if version_between("8.0", "12.0") else {}
     for xml_filename, root in roots.items():
         kw = {"xml_filename": xml_filename} if version_gte("8.saas~6") else {}
@@ -1250,7 +1259,7 @@ def __update_record_from_xml(
         importer.parse(root, **parse_kw)
 
     if version_gte("13.0"):
-        flush(env(cr)["base"])
+        flush(new_env["base"])
 
     if noupdate:
         force_noupdate(cr, xmlid, noupdate=True)


### PR DESCRIPTION
Issue:
A cache desynchronization can happen when a record is first loaded in the ORM cache and later updated directly using `cr.execute()`.

In that case, the database value changes, but the ORM cache still keeps the old value because the record is not reloaded or invalidated.

When `update_record_from_xml()` is called again for the same record, `_update_cache()` is not triggered because the cached value is still considered identical [1] [2].

As a result:
- the ORM keeps stale values in cache
- the field is not marked dirty
- flush/commit only synchronizes the dirtly field [3]

Fix:
Invalidate the environment cache before calling
`update_record_from_xml()` again so the ORM reloads fresh values from the database before performing the write.

[1]: https://github.com/odoo/odoo/blob/8d14665af5acf1bd391d05a5048dc701986e8b15/odoo/orm/fields.py#L1629-L1630
[2]: https://github.com/odoo/odoo/blob/8d14665af5acf1bd391d05a5048dc701986e8b15/odoo/orm/fields.py#L1520
[3]: https://github.com/odoo/odoo/blob/8d14665af5acf1bd391d05a5048dc701986e8b15/odoo/orm/environments.py#L384