### PR TITLE
[IMP] util/orm: invalidate cached values after load from XML

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -36,7 +36,7 @@ from .inconsistencies import break_recursive_loops
 from .indirect_references import indirect_references
 from .inherit import direct_inherit_parents, for_each_inherit
 from .misc import AUTOMATIC, chunks, version_between, version_gte
-from .orm import env, flush
+from .orm import env, flush, invalidate
 from .pg import (
     PGRegexp,
     SQLStr,
@@ -1250,7 +1250,8 @@ def __update_record_from_xml(
         importer.parse(root, **parse_kw)
 
     if version_gte("13.0"):
-        flush(env(cr)["base"])
+        flush(cr_or_env["base"])
+        invalidate(cr_or_env["base"])
 
     if noupdate:
         force_noupdate(cr, xmlid, noupdate=True)


### PR DESCRIPTION
All environments share the same transaction object. The initial field cache for a fresh environment is taken from the transaction. https://github.com/odoo/odoo/blob/8d14665af5acf1bd391d05a5048dc701986e8b15/odoo/orm/fields.py#L1527-L1550

When we load twice the same record and in-between we update it, the cache will be inconsistent.

For example, if field X is updated multiple times via load from XML and queries (all in pre- of the same module, possibly in different scripts), pattern:
```py
util.update_record_from_xml(cr, "module.my_record")  # (1) updates field X
cr.execute("UPDATE ...") # (2) update X for `module.my_record` directly in the DB

util.update_record_from_xml(cr, "module.my_record")  # (3) expected: update X back
```
In `(3)` the ORM reuses the field cache updated by `(1)`. But it would "see" a non dirty value, since it cannot know about `(2)`.

This pattern is prone to cause errors. We propose here to ensure the cache is properly invalidated.