### PR TITLE
[FIX] base/17.0: fix false field match in find_target

### DIFF
--- a/src/base/17.0.1.3/attr_domains2expr.py
+++ b/src/base/17.0.1.3/attr_domains2expr.py
@@ -150,7 +150,7 @@ def target_elem_and_view_type(elem, comb_arch):
             else:
                 it = (
                     x
-                    for x in comb_arch.iter("field")
+                    for x in comb_arch.iter(elem.tag)
                     if all(x.get(k) == elem.get(k) for k in elem.attrib if k != "position")
                 )
             return next(it, elem)


### PR DESCRIPTION
`find_target` was adapted from Odoo's [`locate_node`], but mistakenly hardcoded `"field"` instead of [`elem.tag`] in the else part

This means a non-field positional element like
`<notebook colspan="4" position="inside">` would search `comb_arch` for a `<field>` matching its attributes, accidentally finding any field with `colspan="4"`. That field's parent chain leads back to the same notebook, which resolves to the same field again -> infinite loop -> `MemoryError`.
```py
File "/tmp/tmpuax9w501/migrations/base/saas~16.5.1.3/end-01-attrs-views.py", line 73, in migrate
    _migrate(cr, fix_attrs, check_arch, _logger)
  File "/tmp/tmpuax9w501/migrations/base/saas~16.5.1.3/end-01-attrs-views.py", line 153, in _migrate
    new_archs = fix_archs(info)
  File "/tmp/tmpuax9w501/migrations/base/saas~16.5.1.3/end-01-attrs-views.py", line 126, in fix_archs
    if not fix_attrs(cr, v.model, arch, comb_arch):
  File "/tmp/tmpuax9w501/migrations/base/17.0.1.3/attr_domains2expr.py", line 365, in fix_attrs
    success &= fix_elem(cr, model, elem, comb_arch)
  File "/tmp/tmpuax9w501/migrations/base/17.0.1.3/attr_domains2expr.py", line 195, in fix_elem
    telem, inner_view_type, field_path = target_elem_and_view_type(elem, comb_arch)
  File "/tmp/tmpuax9w501/migrations/base/17.0.1.3/attr_domains2expr.py", line 181, in target_elem_and_view_type
    field_path.append(pelem.get("name"))
MemoryError
```

opw-6276538
upg-4300127

[`locate_node`]: https://github.com/odoo/odoo/blob/4fec6300/odoo/tools/template_inheritance.py#L60-L94
[`elem.tag`]: https://github.com/odoo/odoo/blob/4fec6300/odoo/tools/template_inheritance.py#L91