### PR TITLE
[IMP] util.create_column: use FK column type

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1199,6 +1199,23 @@ class TestPG(UnitTestCase):
         target = util.target_of(cr, "res_partner", "_test_lang_id")
         self.assertEqual(target, ("res_lang", "id", "res_partner__test_lang_id_fkey"))
 
+    def test_create_column_inferred_type_with_fk(self):
+        cr = self.env.cr
+        self.assertFalse(util.column_exists(cr, "res_partner", "_test_lang_id"))
+
+        with self.assertRaises(ValueError):
+            util.create_column(cr, "res_partner", "_test_lang_id", util.AUTO)
+
+        util.create_column(cr, "res_partner", "_test_lang_id", util.AUTO, fk_table="res_lang")
+
+        self.assertTrue(util.column_exists(cr, "res_partner", "_test_lang_id"))
+        expected_type = util.column_type(cr, "res_lang", "id")
+        actual_type = util.column_type(cr, "res_partner", "_test_lang_id")
+        self.assertEqual(actual_type, expected_type)
+
+        target = util.target_of(cr, "res_partner", "_test_lang_id")
+        self.assertEqual(target, ("res_lang", "id", "res_partner__test_lang_id_fkey"))
+
     def test_ColumnList(self):
         cr = self.env.cr
 

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -645,9 +645,10 @@ def create_column(cr, table, column, definition, **kwargs):
 
     :param str table: table of the new column
     :param str column: name of the new column
-    :param str definition: column type of the new column
+    :param str definition: column type of the new column. Use :data:`~odoo.upgrade.util.misc.AUTO`
+                           to infer the type from the `id` column of `fk_table`.
     :param bool default: default value to set on the new column
-    :param bool fk_table: if the new column if a foreign key, name of the foreign table
+    :param str fk_table: if the new column is a foreign key, name of the foreign table
     :param str on_delete_action: `ON DELETE` clause, default `NO ACTION`, only valid if
                                   the column is a foreign key.
     :return: whether the column was created
@@ -675,7 +676,12 @@ def create_column(cr, table, column, definition, **kwargs):
     elif on_delete_action is not no_def:
         raise ValueError("`on_delete_action` argument can only be used if `fk_table` argument is set.")
 
-    definition = _normalize_pg_type(definition)
+    if definition is AUTO:
+        if fk_table is no_def:
+            raise ValueError("AUTO definition can only be used if `fk_table` argument is set.")
+        definition = column_type(cr, fk_table, "id")
+    else:
+        definition = _normalize_pg_type(definition)
 
     if definition == "bool" and default is no_def:
         default = False


### PR DESCRIPTION
Before, the column type had to be hardcoded even if the column would be used for a foreign key. This could lead to errors when the type of the related column was changed. ([example])

This commit would allow to derive the column type from the related column type if the column is used for a FK.

[example]: https://github.com/odoo/upgrade/pull/10503