### PR TITLE
[FIX] util/misc: `once` check current version when missing env

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -2474,6 +2474,8 @@ class TestOnce(UnitTestCase):
             # Explicit interval covering the first step
             ("16.0", "17.0", "18.0", [("17.0", True), ("18.0", False)]),
             ("16.0", "17.0", None, [("17.0", True), ("18.0", False)]),
+            # Open lower bound defaults to the source version: first step still fires
+            ("16.0", None, "18.0", [("17.0", True), ("18.0", False)]),
             # Explicit interval starting mid-path
             ("16.0", "18.0", "18.0", [("17.0", False), ("18.0", True)]),
             ("16.0", "17.0", "18.0", [("17.0", True), ("18.0", False), ("19.0", False)]),
@@ -2524,25 +2526,74 @@ class TestOnce(UnitTestCase):
                     action()
                     self.assertEqual(calls, {1} if expected else set(), "decorator: " + msg)
 
-    def test_once_no_env_vars(self):
-        # When source/target are unknown, once is always truthy regardless of series
-        with mock.patch.object(util.misc, "_SOURCE_VERSION", None), mock.patch.object(
-            util.misc, "_TARGET_VERSION", None
-        ):
-            for series in ("16.0", "17.0", "18.0", "19.0", "saas~19.4"):
-                with mock.patch.object(util.misc.release, "serie", series):  # "serie" is an old typo  # noqa: TYPOS
-                    o = util.once("17.0", "18.0")
-                    self.assertTrue(o, "series={!r} should be True when env vars absent".format(series))
+    # When source/target are unknown (env vars unset) or equal (master->master freeze), `once`
+    # cannot rely on the step path. It falls back to evaluating the interval against the currently
+    # running series, with an open bound (``None``) meaning unbounded on that side. At least one
+    # bound must be set.
+    # Each case: (lower, upper, series, expected)
+    @parametrize(
+        [
+            # Bounded interval [lower, upper]: truthy iff series in range (inclusive)
+            ("17.0", "18.0", "16.0", False),
+            ("17.0", "18.0", "17.0", True),
+            ("17.0", "18.0", "saas~17.4", True),
+            ("17.0", "18.0", "18.0", True),
+            ("17.0", "18.0", "saas~18.1", False),
+            ("17.0", "18.0", "19.0", False),
+            ("saas~17.2", "saas~18.4", "17.0", False),
+            ("saas~17.2", "saas~18.4", "saas~17.2", True),
+            ("saas~17.2", "saas~18.4", "18.0", True),
+            ("saas~17.2", "saas~18.4", "saas~18.4", True),
+            ("saas~17.2", "saas~18.4", "saas~18.5", False),
+            # Open upper bound (>= lower): truthy iff series >= lower
+            ("18.0", None, "17.0", False),
+            ("18.0", None, "saas~17.4", False),
+            ("18.0", None, "18.0", True),
+            ("18.0", None, "saas~18.4", True),
+            ("18.0", None, "19.0", True),
+            ("saas~18.2", None, "18.0", False),
+            ("saas~18.2", None, "saas~18.2", True),
+            ("saas~18.2", None, "saas~18.4", True),
+            # Open lower bound (<= upper): truthy iff series <= upper (upper match is at major.minor)
+            (None, "18.0", "17.0", True),
+            (None, "18.0", "saas~17.5", True),
+            (None, "18.0", "18.0", True),
+            (None, "18.0", "saas~18.4", False),
+            (None, "18.0", "19.0", False),
+            (None, "saas~18.4", "saas~18.4", True),
+            (None, "saas~18.4", "saas~18.3", True),
+            (None, "saas~18.4", "saas~18.5", False),
+        ]
+    )
+    def test_once_no_step_path(self, lower, upper, series, expected):
+        # The unset-env and equal-source/target cases share the same fallback code path; check both.
+        calls = set()
+        for source, target in ((None, None), ("saas~19.4", "saas~19.4")):
+            with mock.patch.object(util.misc, "_SOURCE_VERSION", source), mock.patch.object(
+                util.misc, "_TARGET_VERSION", target
+            ), mock.patch.object(util.misc.release, "serie", series):  # "serie" is an old typo  # noqa: TYPOS
+                msg = "src={!r} series={!r} once({!r}, {!r})".format(source, series, lower, upper)
 
-    def test_once_same_source_target(self):
-        # master->master freeze: source == target, once is always truthy
-        with mock.patch.object(util.misc, "_SOURCE_VERSION", "saas~19.4"), mock.patch.object(
-            util.misc, "_TARGET_VERSION", "saas~19.4"
-        ):
-            for series in ("saas~19.4", "19.0", "18.0"):
-                with mock.patch.object(util.misc.release, "serie", series):  # "serie" is an old typo  # noqa: TYPOS
-                    o = util.once(None, None)
-                    self.assertTrue(o, "series={!r} should be True when source == target".format(series))
+                o = util.once(lower, upper)
+                self.assertEqual(bool(o), expected, msg)
+
+                calls.clear()
+
+                @util.once(lower, upper)
+                def action():
+                    calls.add(1)
+
+                action()
+                self.assertEqual(calls, {1} if expected else set(), "decorator: " + msg)
+
+    def test_once_requires_a_bound_without_step_path(self):
+        # Without a step path there is no source/target to default an open bound to, so passing
+        # neither bound is an error. Rejected in both the unset-env and equal-source/target contexts.
+        for source, target in ((None, None), ("saas~19.4", "saas~19.4")):
+            with mock.patch.object(util.misc, "_SOURCE_VERSION", source), mock.patch.object(
+                util.misc, "_TARGET_VERSION", target
+            ), self.assertRaises(AssertionError, msg="src={!r} target={!r}".format(source, target)):
+                util.once(None, None)
 
 
 @unittest.skipUnless(util.version_gte("15.0"), "Only works on Odoo >= 15 (python >= 3.7)")

--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -2453,6 +2453,14 @@ def not_doing_anything_converter(el):
 
 
 class TestOnce(UnitTestCase):
+    def setUp(self):
+        super().setUp()
+        # `once` records fired call-sites in this shared store; each test (and each parametrized
+        # case, which reuses the same source line as a key) must start from a clean slate.
+        once_ran = util.ENVIRON["__once_ran"]
+        once_ran.clear()
+        self.addCleanup(once_ran.clear)
+
     # Each case: (source, lower, upper, steps_and_expected)
     # source: the DB version before the upgrade starts target is inferred as the last step in steps_and_expected
     # steps_and_expected: list of (series, expected), the steps visited in order.
@@ -2569,6 +2577,9 @@ class TestOnce(UnitTestCase):
         # The unset-env and equal-source/target cases share the same fallback code path; check both.
         calls = set()
         for source, target in ((None, None), ("saas~19.4", "saas~19.4")):
+            # Each iteration is an independent scenario; reset the shared once-dedup store so the
+            # call-site below is not considered already-fired from the previous iteration.
+            util.ENVIRON["__once_ran"].clear()
             with mock.patch.object(util.misc, "_SOURCE_VERSION", source), mock.patch.object(
                 util.misc, "_TARGET_VERSION", target
             ), mock.patch.object(util.misc.release, "serie", series):  # "serie" is an old typo  # noqa: TYPOS
@@ -2594,6 +2605,68 @@ class TestOnce(UnitTestCase):
                 util.misc, "_TARGET_VERSION", target
             ), self.assertRaises(AssertionError, msg="src={!r} target={!r}".format(source, target)):
                 util.once(None, None)
+
+    def test_once_consumed_after_first_evaluation(self):
+        # A script may be symlinked more than once in the same major version. A truthy `once`
+        # instance must fire only on the *first* evaluation; any further evaluation of the same
+        # instance is falsy, so the guarded code never runs twice on the same step.
+        # Use a step path that makes `once` truthy at the current series.
+        with mock.patch.object(util.misc, "_SOURCE_VERSION", "16.0"), mock.patch.object(
+            util.misc, "_TARGET_VERSION", "18.0"
+        ), mock.patch.object(util.misc.release, "serie", "17.0"):  # "serie" is an old typo  # noqa: TYPOS
+            # As a boolean: first shot truthy, subsequent shots falsy.
+            o = util.once("17.0", "18.0")
+            self.assertTrue(bool(o), "first evaluation should fire")
+            self.assertFalse(bool(o), "second evaluation must be consumed")
+            self.assertFalse(bool(o), "still falsy on further evaluations")
+
+            # As a decorator: the wrapped function runs only on the first call.
+            calls = []
+
+            @util.once("17.0", "18.0")
+            def action():
+                calls.append(1)
+
+            action()
+            action()
+            action()
+            self.assertEqual(calls, [1], "decorator body must run only once across repeated calls")
+
+            # A *falsy* instance stays falsy and never runs (and consumption keeps it falsy).
+            never = util.once("19.0", "saas~19.3")
+            self.assertFalse(bool(never))
+            self.assertFalse(bool(never))
+
+    def test_once_deduped_across_instances_in_same_step(self):
+        # The real symlink case: the same script runs several times in one step, each run building
+        # a *fresh* `once` object. They share a call-site (same file + line), so only the first must
+        # fire. `make` returns a new instance from a single source line, mimicking repeated runs.
+        def make():
+            return util.once("17.0", "18.0")
+
+        with mock.patch.object(util.misc, "_SOURCE_VERSION", "16.0"), mock.patch.object(
+            util.misc, "_TARGET_VERSION", "saas~18.4"
+        ):
+            # `("17.0", "18.0")` is truthy at the first step landing in range, here series 17.0.
+            with mock.patch.object(util.misc.release, "serie", "17.0"):  # "serie" is an old typo  # noqa: TYPOS
+                fired = [bool(make()) for _ in range(3)]
+                self.assertEqual(fired, [True, False, False], "fresh instances at one call-site fire once")
+
+            # The call-site key includes the running series, so a *different* step is independent:
+            # a fresh instance evaluated at series 18.0 is gated only by its own (falsy here) check.
+            with mock.patch.object(util.misc.release, "serie", "18.0"):  # "serie" is an old typo  # noqa: TYPOS
+                self.assertFalse(bool(make()), "out-of-step instance does not fire")
+
+    def test_once_handles_caller_without_real_file(self):
+        # `once` may be built from code with no real file on disk (e.g. an exec'd snippet, as done
+        # by `util.import_script`). Resolving the call-site must not crash and behaviour is unchanged.
+        code = compile("o = util.once('17.0', '18.0'); res = [bool(o), bool(o)]", "<string>", "exec")
+        with mock.patch.object(util.misc, "_SOURCE_VERSION", "16.0"), mock.patch.object(
+            util.misc, "_TARGET_VERSION", "18.0"
+        ), mock.patch.object(util.misc.release, "serie", "17.0"):  # "serie" is an old typo  # noqa: TYPOS
+            ns = {"util": util}
+            exec(code, ns)
+            self.assertEqual(ns["res"], [True, False], "per-instance consumption still holds")
 
 
 @unittest.skipUnless(util.version_gte("15.0"), "Only works on Odoo >= 15 (python >= 3.7)")

--- a/src/util/const.py
+++ b/src/util/const.py
@@ -16,6 +16,7 @@ ENVIRON = {
     "__modules_to_skip_autoinstall": set(),
     "__fix_fk_allowed_cascade": [],
     "__no_model_data_delete": {},
+    "__once_ran": set(),
 }
 
 NEARLYWARN = 25  # between info and warning; appear on runbot build page

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -146,7 +146,8 @@ class once(object):
     every other step it evaluates to falsy.
 
     When the environment variables are absent (e.g. in a single-step or standalone run), the
-    object is always truthy so the code is never accidentally skipped.
+    object is truthy when the current version is in the interval ``[lower, upper]``. A ``None``
+    value means unbound. At least one bound must be set.
 
     It can be used as a plain boolean or as a decorator:
 
@@ -188,7 +189,13 @@ class once(object):
 
         # When running locally the env vars may be unset. In CI we do master->master upgrade for the freeze
         if _SOURCE_VERSION is None or _TARGET_VERSION is None or _SOURCE_VERSION == _TARGET_VERSION:
-            self.check = True
+            assert lower is not None or upper is not None, "consider a 0.0.0 script instead"
+            if upper is None:  # >= lower
+                self.check = version_gte(lower)
+            elif lower is None:  # <= upper
+                self.check = parse_version(upper)[:2] == parse_version(release.serie)[:2] or not version_gte(upper)
+            else:
+                self.check = version_between(lower, upper)
             return
 
         s, t = parse_version(_SOURCE_VERSION), parse_version(_TARGET_VERSION)

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -33,6 +33,7 @@ if release.major_version == "7.0":
         return _parse_version(version.replace("saas~", ""))
 
 
+from .const import ENVIRON
 from .exceptions import MigrationError, SleepyDeveloperError
 
 # python3 shim
@@ -187,6 +188,12 @@ class once(object):
     def __init__(self, lower, upper, logger=None):
         self._logger = logger
 
+        # Symlinked scripts could run more than once in the same upgrade step. To ensure single run
+        # we keep the info in ENVIRON.
+        # NOTE: `once` via import_script gets the caller file and line
+        frame = sys._getframe(1)
+        self._key = "{}:{}".format(os.path.realpath(frame.f_code.co_filename), frame.f_lineno)
+
         # When running locally the env vars may be unset. In CI we do master->master upgrade for the freeze
         if _SOURCE_VERSION is None or _TARGET_VERSION is None or _SOURCE_VERSION == _TARGET_VERSION:
             assert lower is not None or upper is not None, "consider a 0.0.0 script instead"
@@ -226,10 +233,13 @@ class once(object):
         return self.__bool__()
 
     def __bool__(self):
+        must_run = self.check and self._key not in ENVIRON["__once_ran"]
+        if must_run:
+            ENVIRON["__once_ran"].add(self._key)
         if self._logger:
-            op = "run" if self.check else "skip"
-            self._logger.info("%s once in version %s", op, release.serie)
-        return self.check
+            op = "run" if must_run else "skip"
+            self._logger.info("%s key, %s once in version %s", self._key, op, release.serie)
+        return must_run
 
     def __call__(self, func=None):
         assert callable(func)


### PR DESCRIPTION
`once` is to guard code execution, the bound must be respected even if
there is no env vars.
