### PR TITLE
[FIX] base/0.0.0: fix SleepyDeveloperError test module

### DIFF
--- a/src/util/helpers.py
+++ b/src/util/helpers.py
@@ -21,6 +21,15 @@ _VALID_MODELS = frozenset(
         "o2m_readonly_subfield_child",
         "o2m_changes_parent",
         "o2m_changes_children",
+        # test_inherit
+        "test_mother_underscore",
+        "test_inherit_daughter",
+        "test_inherit_property",
+        "test_inherit_parent",
+        "test_inherit_child",
+        "test_inherit_mixin",
+        # test_orm
+        "test_ir_qweb_fields",
     }
     | ({"l10n_pl_tax_office"} if version_between("16.0", "17.0") else set())
     | {m.strip() for m in os.getenv("UPG_VALID_MODELS", "").split(";")} - {""}


### PR DESCRIPTION
Steps To Reproduce :-
- Install `test_inherit` in v18.3.
- upgrade to v19 fail with this error.

Error :-
```
 File "/tmp/tmpcxl9d0z9/migrations/util/helpers.py", line 146, in
_validate_model
    raise SleepyDeveloperError("`{}` seems to be a table name instead of model
name".format(model))
odoo.upgrade.util.exceptions.SleepyDeveloperError: `test_mother_underscore`
seems to be a table name instead of model name
```

Reason :- 
- Test modules are uninstalled [here](https://github.com/odoo/upgrade/blob/master/migrations/base/0.0.0/pre-uninstall-modules.py#L15-L24), while uninstalling, test_inherit contained some [uncommon model names](https://github.com/odoo/odoo/blob/saas-18.3/odoo/addons/test_inherit/models/mother_inherit_1.py#L25) failing [here](https://github.com/odoo/upgrade-util/blame/master/src/util/helpers.py#L144-L147).
- later new uncommon named model [test_ir_qweb_fields](https://github.com/odoo/odoo/blame/saas-19.3/odoo/addons/test_orm/models/test_ir_qweb_fields.py#L5) was added in test_orm .

upg : [4392491](https://upgrade.odoo.com/odoo/request/4392491)
opw : [6146716](https://www.odoo.com/odoo/project/70/tasks/6146716)