### PR TITLE
[IMP] base/0.0.0: lower logging level when a computed field respawns

### DIFF
--- a/src/base/0.0.0/end-no-respawn-fields.py
+++ b/src/base/0.0.0/end-no-respawn-fields.py
@@ -50,11 +50,11 @@ def migrate(cr, version):
         qualifier = "field" if store else "non-stored field"
         if transient:
             qualifier = "transient " + qualifier
-        lvl = util.NEARLYWARN if transient or not store else logging.CRITICAL
+        lvl = logging.INFO if transient or not store else logging.CRITICAL
         action = ""
 
         if "{}/{}".format(model, field) in ignored_fields_respawn:
             lvl = util.NEARLYWARN
             action = "; explicitly ignored"
 
-        _logger.log(lvl, "%s %s/%s has respawn%s.", qualifier, model, field, action)
+        _logger.log(lvl, "%s %s/%s has respawned%s", qualifier, model, field, action)


### PR DESCRIPTION
NEARLYWARN causes the entry to show up in the runbot logs, where it's a lot of spam and not a lot of utility: https://runbot.odoo.com/runbot/build/115510163