### PR TITLE
[IMP] util/pg: reduce query count

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -498,8 +498,20 @@ def pg_text2html(s, wrap="p"):
     )
 
 
+_JSONB_COLUMNS = {}
+if version_gte("17.0"):  # switched to jsonb in 16.0
+    _JSONB_COLUMNS[("ir_ui_view", "arch_db")] = True
+    _JSONB_COLUMNS[("ir_act_server", "name")] = True
+    _JSONB_COLUMNS[("ir_model", "name")] = True
+
+
 def get_value_or_en_translation(cr, table, column):
-    fmt = "{}->>'en_US'" if column_type(cr, table, column) == "jsonb" else "{}"
+    is_jsonb = (
+        _JSONB_COLUMNS[(table, column)]
+        if (table, column) in _JSONB_COLUMNS
+        else column_type(cr, table, column) == "jsonb"
+    )
+    fmt = "{}->>'en_US'" if is_jsonb else "{}"
     return format_query(cr, fmt, column)
 
 

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -258,8 +258,8 @@ def edit_view(cr, xmlid=None, view_id=None, skip_if_not_noupdate=True, active="a
             view_id, noupdate = data
 
     if view_id and not (skip_if_not_noupdate and not noupdate):
-        arch_col = "arch_db" if column_exists(cr, "ir_ui_view", "arch_db") else "arch"
-        jsonb_column = column_type(cr, "ir_ui_view", arch_col) == "jsonb"
+        arch_col = "arch_db" if version_gte("10.0") or column_exists(cr, "ir_ui_view", "arch_db") else "arch"
+        jsonb_column = version_gte("17.0") or column_type(cr, "ir_ui_view", arch_col) == "jsonb"
         cr.execute(
             """
                 SELECT {arch}


### PR DESCRIPTION
The call to `column_info` for `ir_ui_view/arch_db` runs 56K times in an
upgrade 19->19.4 with a runbot enterprise DB.
