### PR TITLE
[FIX] util/domains: add version check for model_name

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -147,7 +147,7 @@ def _get_domain_fields(cr):
             )
         ]
 
-    if column_exists(cr, "base_automation", "action_server_id"):
+    if column_exists(cr, "base_automation", "action_server_id") and not version_gte("saas~18.1"):
         result += [
             DomainField(
                 "base_automation",


### PR DESCRIPTION
The field [`model_name`] has become `store=f` in `v18.1` and its column is [removed] from upgrade too.

Traceback:
```py
  File "/tmp/tmpd0m7olzw/migrations/util/fields.py", line 259, in remove_field
    adapt_domains(
  File "/tmp/tmpd0m7olzw/migrations/util/domains.py", line 479, in adapt_domains
    cr.execute(query, [target_model, match_old, dot_old])
  File "/home/odoo/src/odoo/19.0/odoo/sql_db.py", line 440, in execute
    self._obj.execute(query, params)
psycopg2.errors.UndefinedColumn: column "model_name" does not exist
LINE 2:                 SELECT id, (SELECT model_name FROM ir_act_se...
                                           ^
```

[`model_name`]: https://github.com/odoo/odoo/blob/68f258e99f42693131a5309b3606c3b95f93d824/odoo/addons/base/models/ir_actions.py#L638
[removed]: https://github.com/odoo/upgrade/blob/master/migrations/base/saas~18.1.1.3/pre-migrate.py#L6