### PR TITLE
[FIX] util/records.py: add required visibilty in add_view

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -2113,6 +2113,20 @@ class TestRecords(UnitTestCase):
         self.assertTrue(cat_2.exists())
         self.assertFalse(cat_3.exists())
 
+    def test_add_view(self):
+        cr = self.env.cr
+        arch = '<form><field name="name"/></form>'
+        view_id = util.add_view(cr, "test_add_view", "res.partner", "form", arch)
+        self.assertTrue(view_id)
+        cr.execute(
+            "SELECT name, model, type FROM ir_ui_view WHERE id = %s",
+            [view_id],
+        )
+        name, model, view_type = cr.fetchone()
+        self.assertEqual(name, "test_add_view")
+        self.assertEqual(model, "res.partner")
+        self.assertEqual(view_type, "form")
+
 
 class TestEditView(UnitTestCase):
     @parametrize(

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -38,6 +38,7 @@ from .inherit import direct_inherit_parents, for_each_inherit
 from .misc import AUTOMATIC, chunks, version_between, version_gte
 from .orm import env, flush
 from .pg import (
+    ColumnList,
     PGRegexp,
     SQLStr,
     _get_unique_indexes_with,
@@ -322,13 +323,24 @@ def add_view(cr, name, model, view_type, arch_db, inherit_xml_id=None, priority=
     arch_col = "arch_db" if column_exists(cr, "ir_ui_view", "arch_db") else "arch"
     jsonb_column = column_type(cr, "ir_ui_view", arch_col) == "jsonb"
     arch_column_value = Json({"en_US": arch_db}) if jsonb_column else arch_db
+    extra = (
+        [arch_col]
+        + (["key"] if key_exist else [])
+        + (["visibility"] if column_exists(cr, "ir_ui_view", "visibility") and version_gte("saas~19.3") else [])
+    )
+    columns = ColumnList.from_unquoted(cr, extra)
+    params = ["%({})s".format(x) for x in extra]
     cr.execute(
-        """
-        INSERT INTO ir_ui_view(name, "type",  model, inherit_id, mode, active, priority, %s)
-        VALUES(%%(name)s, %%(view_type)s, %%(model)s, %%(inherit_id)s, %%(mode)s, 't', %%(priority)s, %%(arch_db)s %s)
-        RETURNING id
-    """
-        % (arch_col + (", key" if key_exist else ""), ", %(key)s" if key_exist else ""),
+        format_query(
+            cr,
+            """
+            INSERT INTO ir_ui_view(name, "type",  model, inherit_id, mode, active, priority{columns})
+            VALUES(%(name)s, %(view_type)s, %(model)s, %(inherit_id)s, %(mode)s, 't', %(priority)s{values})
+            RETURNING id
+            """,
+            columns=columns.using(leading_comma=True),
+            values=SQLStr(", " + ", ".join(params)),
+        ),
         {
             "name": name,
             "view_type": view_type,
@@ -337,7 +349,8 @@ def add_view(cr, name, model, view_type, arch_db, inherit_xml_id=None, priority=
             "mode": "extension" if inherit_id else "primary",
             "priority": priority,
             "key": key,
-            "arch_db": arch_column_value,
+            "visibility": "public",
+            arch_col: arch_column_value,
         },
     )
     return cr.fetchone()[0]


### PR DESCRIPTION
The visibility field is now [required](https://github.com/odoo/odoo/commit/6fdb9a1a1215426a78a8824594db0c3c470b2d89)
 on the ir.ui.view model. Set the default
value to public in the add_view() helper when creating new views. https://github.com/odoo/upgrade-util/blob/743d75c99e13c26ec4a6e95619a5f6c24d3ee990/src/util/records.py#L310