### PR TITLE
[FIX] util: fix doc string

### DIFF
--- a/src/util/modules.py
+++ b/src/util/modules.py
@@ -124,7 +124,7 @@ def modules_installed(cr, *modules):
     """
     Return whether *all* given modules are installed.
 
-    :param list(str) modules: names of the modules to check
+    :param str modules: one or more module names to check (variadic)
     :rtype: bool
 
     .. note::


### PR DESCRIPTION
fix misleading doc string if do ``list(str)`` it can cause the error.
```
2026-07-14 09:34:42,030 37452 ERROR test_test_19.0_test odoo.sql_db: bad query: b"\n            SELECT count(1)\n              FROM ir_module_module\n             WHERE name IN (ARRAY['l10n_vn_edi_viettel','stock'])\n               AND state IN ('installed', 'to install', 'to upgrade')\n    "
ERROR: operator does not exist: character varying = text[]
LINE 4:              WHERE name IN (ARRAY['l10n_vn_edi_viettel','sto...
                                ^
```