### PR TITLE
[FIX] util: fix migration report

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -3068,19 +3068,8 @@ class TestAssertUpdated(UnitTestCase):
 
 
 class TestReportUtils(UnitTestCase):
-    def test_report_simple(self):
-        self.assertEqual(
-            util.report_with_list(
-                summary="Simple test with minimal arguments and no data.",
-                data=[],
-                columns=("id", "name"),
-                row_format="Partner {name} has id {id}.",
-            ),
-            "<summary>Simple test with minimal arguments and no data.</summary>",
-        )
-
     def test_report_links(self):
-        self.assertEqual(
+        self.assertFalse(
             util.report_with_list(
                 summary="Testing links.",
                 data=[],
@@ -3088,7 +3077,6 @@ class TestReportUtils(UnitTestCase):
                 row_format="Partner {partner_link}.",
                 links={"partner_link": ("res.partner", "id", "name")},
             ),
-            "<summary>Testing links.</summary>",
         )
 
     def test_report_data_minimal(self):

--- a/src/util/report.py
+++ b/src/util/report.py
@@ -152,6 +152,9 @@ def report_with_list(summary, data, columns, row_format, links=None, total=None,
     The entry consists of a category (title) and a summary (body).
     The entry displays a list of records previously returned by SQL query, or any list.
 
+    .. warning::
+            If the list to render would be empty, nothing is posted in the report.
+
     .. example::
 
         .. code-block:: python
@@ -170,8 +173,7 @@ def report_with_list(summary, data, columns, row_format, links=None, total=None,
 
     :param str summary: description of a report entry.
     :param list(tuple) data: data to report, each entry would be a row in the report.
-                             It could be empty, in which case only the summary is rendered.
-    :param tuple(str) columns: columns in `data`, can be referenced in `row_format`.
+    :param tuple(str) columns: columns in `data`, can be referenced in `row_format`
     :param str row_format: format for rows, can use any name from `columns` or `links`, e.g.:
                            "Partner {partner_link} that lives in {city} works at company {company_link}."
     :param dict(str, tuple(str, str, str)) links: optional model/record links spec,
@@ -198,15 +200,14 @@ def report_with_list(summary, data, columns, row_format, links=None, total=None,
             )
         return "<li>{}</li>".format(row_format.format(**row_dict))
 
-    if not data:
-        row_to_html(columns)  # Validate the format is correct, including links
-        return report_with_summary(summary=summary, details="", category=category)
-
     disclaimer = "The total number of affected records is {}. ".format(total) if total else ""
     total = len(data) if total is None else total
     limit = min(limit, total) if limit is not None else total
     if total > limit:
         disclaimer += "This list is showing the first {} records.".format(limit)
+    if not data[:limit]:
+        row_to_html(columns)  # Validate the format is correct, including links
+        return None  # there is nothing to show in the list
 
     rows = "<ul>\n" + "\n".join([row_to_html(row) for row in data[:limit]]) + "\n</ul>"
     return report_with_summary(summary, "<i>{}</i>{}".format(disclaimer, rows), category)


### PR DESCRIPTION
Skip generating the summary if no data:

This prevents summary from being added to the migration
report if there is nothing to add. If really wants to add
summary only use the "report_with_summary" method [example]

[example]: https://github.com/odoo/upgrade/blame/ed551c9fda560287ca3c39d47f152dce2e9564a0/migrations/base/0.0.0/pre-match-partner_company.py#L27

<img width="1323" height="149" alt="image" src="https://github.com/user-attachments/assets/31ebe45b-1313-4330-b9a4-7076f51fa56d" />
