### PR TITLE
[FIX] util/records: make xml_filname fully qualified

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1866,6 +1866,21 @@ class TestRecords(UnitTestCase):
         cr.execute(query, [record_id])
         self.assertEqual(cr.fetchone()[0], original)
 
+    def test_update_record_from_xml_resets_arch_fs_noupdate(self):
+        cr = self.env.cr
+        xmlid = "base.contact_name"
+
+        view = self.env["ir.ui.view"].browse(util.ref(cr, xmlid))
+
+        original_arch_fs = view.arch_fs
+        view.arch_fs = False
+        util.flush(view)
+
+        util.update_record_from_xml(cr, xmlid)
+        util.invalidate(view)
+
+        self.assertEqual(original_arch_fs, view.arch_fs)
+
     def test_ensure_xmlid_match_record(self):
         cr = self.env.cr
         tx1 = self.env["res.currency"].create({"name": "TX1", "symbol": "TX1"})

--- a/src/util/records.py
+++ b/src/util/records.py
@@ -67,6 +67,19 @@ try:
 except NameError:
     basestring = unicode = str
 
+if version_gte("15.0"):
+    from odoo.tools.misc import file_path
+elif version_gte("9.0"):
+    try:
+        from odoo.modules.module import get_resource_path
+    except ImportError:
+        from openerp.modules.module import get_resource_path
+
+    file_path = lambda path: get_resource_path(*path.split("/", 1))
+else:
+    # doesn't matter as `xml_filename` is not used in older version.
+    file_path = lambda path: path
+
 
 def remove_view(cr, xml_id=None, view_id=None, silent=False, key=None):
     """
@@ -1213,7 +1226,7 @@ def __update_record_from_xml(
             doc = lxml.etree.parse(fp)
             for node in doc.xpath(xpath):
                 found = True
-                xml_filename = "{}/{}".format(from_module, f)
+                xml_filename = file_path("{}/{}".format(from_module, f))
                 root = roots.get(xml_filename)
                 if root is None:
                     # use a data tag inside openerp tag to be compatible with all supported versions


### PR DESCRIPTION
Passing `xml_filename` as `module/file_path` does not work with
`get_resource_from_path()`, as it resolves the resource relative to
`addons.__path__`.

Since `addons.__path__` contains paths such as
`/home/odoo/src/enterprise/<version>` or `/home/odoo/src/odoo/<version>`,
the module name and data file must be resolved from the full module path
before looking up the resource.

See `odoo.modules.module.get_resource_from_path()`[1] for the corresponding
resource resolution logic.

[1]: https://github.com/odoo/odoo/blob/4b1077a5f8726f9139705521cc6e368fb5adba1a/odoo/modules/module.py#L347