### PR TITLE
[FIX] util: Fix attribute error during announce

### DIFF
--- a/src/util/report.py
+++ b/src/util/report.py
@@ -379,7 +379,7 @@ def announce(
             poster = recipient.message_post
         except (ValueError, AttributeError):
             # Cannot find record, post the message on the wall of the admin
-            pass
+            recipient = False
 
     type_field = ["type", "message_type"][version_gte("9.0")]
     # From 12.0, system notificatications are sent by email,


### PR DESCRIPTION
Just in case if "mail.{channel,group}_all_employees" record is missing but during standard upgrade normally it should present. Do assign recipent to False

util can be used outside of standard upgrade scope for that reason only.

```
2026-07-22 18:04:14,739 1 ERROR devel odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 88, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 584, in load_modules
    model._register_hook()
  File "/usr/local/lib/python3.8/site-packages/odoo/upgrade/mail/0.0.0/pre-report-migration.py", line 30, in _register_hook
    util.announce_release_note(self.env.cr)
  File "/usr/local/lib/python3.8/site-packages/odoo/upgrade/util/report.py", line 148, in announce_release_note
    _announce_to_db(cr, message, to_admin_only=False)
  File "/usr/local/lib/python3.8/site-packages/odoo/upgrade/util/report.py", line 189, in _announce_to_db
    announce(cr, release.major_version, message, format="html", header=None, footer=None, **kw)
  File "/usr/local/lib/python3.8/site-packages/odoo/upgrade/util/report.py", line 322, in announce
    domain = [("partner_id", "=", user.partner_id.id), ("channel_id", "=", recipient.id)]
AttributeError: 'str' object has no attribute 'id'
```