### PR TITLE
[FIX] util/report: make `details` optional

### DIFF
--- a/src/util/report.py
+++ b/src/util/report.py
@@ -130,7 +130,7 @@ def report_message(message, category="Other", format="text"):
 add_to_migration_reports = report_message
 
 
-def report_with_summary(summary, details, category="Other"):
+def report_with_summary(summary, details="", category="Other"):
     """Append the upgrade report with a new entry.
 
     :param str summary: Description of a report entry.


### PR DESCRIPTION
`details` had no default, forcing every caller to pass it even when there was nothing to add in details. Default it to "" so callers can omit it.