### PR TITLE
[IMP] util/report: Improve new reporting function

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -3142,9 +3142,9 @@ class TestReportUtils(UnitTestCase):
             else "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=1"
         )
         expected = (
-            "<summary>Test with minimal data.<details><i></i><ul>\n"
+            "<details><summary>Test with minimal data.</summary><ul>\n"
             '<li>Partner <a target="_blank" href="{}">Partner One</a>.</li>\n'
-            "</ul></details></summary>"
+            "</ul></details>"
         ).format(href)
         self.assertEqual(
             util.report_with_list(
@@ -3165,10 +3165,11 @@ class TestReportUtils(UnitTestCase):
             href1 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=1"
             href2 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=2"
         expected = (
-            "<summary>Test with limited data.<details><i>The total number of affected records is 3. This list is showing the first 2 records.</i><ul>\n"
+            "<details><summary>Test with limited data.</summary>"
+            "<i>The total number of affected records is 3. This list is showing the first 2 records.</i><ul>\n"
             '<li>Partner <a target="_blank" href="{}">Partner One</a>.</li>\n'
             '<li>Partner <a target="_blank" href="{}">Partner Two</a>.</li>\n'
-            "</ul></details></summary>"
+            "</ul></details>"
         ).format(href1, href2)
         self.assertEqual(
             util.report_with_list(
@@ -3193,11 +3194,11 @@ class TestReportUtils(UnitTestCase):
             href2 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=2"
             href3 = "/web?debug=1#view_type=form&amp;model=res.partner&amp;action=&amp;id=3"
         expected = (
-            "<summary>Test with limitless data.<details><i></i><ul>\n"
+            "<details><summary>Test with limitless data.</summary><ul>\n"
             '<li>Partner <a target="_blank" href="{}">Partner One</a>.</li>\n'
             '<li>Partner <a target="_blank" href="{}">Partner Two</a>.</li>\n'
             '<li>Partner <a target="_blank" href="{}">Partner Three</a>.</li>\n'
-            "</ul></details></summary>"
+            "</ul></details>"
         ).format(href1, href2, href3)
         self.assertEqual(
             util.report_with_list(

--- a/src/util/report.py
+++ b/src/util/report.py
@@ -138,9 +138,9 @@ def report_with_summary(summary, details, category="Other"):
     :param str category: Title of a report entry.
     """
     msg = (
-        "<summary>{}<details>{}</details></summary>".format(summary, details)
+        "<details><summary>{}</summary>{}</details>".format(summary, details)
         if details
-        else "<summary>{}</summary>".format(summary)
+        else "<p>{}</p>".format(summary)
     )
     report_message(message=msg, category=category, format="html")
     return msg
@@ -200,17 +200,23 @@ def report_with_list(summary, data, columns, row_format, links=None, total=None,
             )
         return "<li>{}</li>".format(row_format.format(**row_dict))
 
-    disclaimer = "The total number of affected records is {}. ".format(total) if total else ""
     total = len(data) if total is None else total
     limit = min(limit, total) if limit is not None else total
-    if total > limit:
-        disclaimer += "This list is showing the first {} records.".format(limit)
-    if not data[:limit]:
+    shown = data[:limit]
+    # Only mention totals/truncation when the list was actually cut off.
+    # A list of 1, or of 98 with a limit of 100, needs no disclaimer at all.
+    if not shown:
         row_to_html(columns)  # Validate the format is correct, including links
         return None  # there is nothing to show in the list
+    disclaimer = ""
+    if total > len(shown):
+        disclaimer = "The total number of affected records is {}. This list is showing the first {} records.".format(
+            total, len(shown)
+        )
 
     rows = "<ul>\n" + "\n".join([row_to_html(row) for row in data[:limit]]) + "\n</ul>"
-    return report_with_summary(summary, "<i>{}</i>{}".format(disclaimer, rows), category)
+    body = "<i>{}</i>{}".format(disclaimer, rows) if disclaimer else rows
+    return report_with_summary(summary, body, category)
 
 
 def announce_release_note(cr):


### PR DESCRIPTION
Description
Problem:-
Several small issues in the upgrade report helpers (report_with_summary / report_with_list) were producing incorrect or misleading output in the generated report UI.

1. ```<details>/<summary>``` nesting was inverted, causing the "Details" toggle to look odd
Before:
```
python"<summary>{}<details>{}</details></summary>".format(summary, details)
```
<img width="1202" height="275" alt="image" src="https://github.com/user-attachments/assets/181543b2-cfd6-42d6-b83e-10c8e5acdcad" />
it will shown every version of field renamed
<img width="1203" height="562" alt="image" src="https://github.com/user-attachments/assets/867d37d7-610a-4ad8-bf91-a565ae3547b4" />
<img width="1100" height="93" alt="image" src="https://github.com/user-attachments/assets/8c051313-5174-4aba-9d93-927862691879" />

Per the HTML5 spec, ```<summary>``` only behaves as a clickable disclosure label when it is the first child of a ```<details> ``` element. Here, the outer ```<summary>``` had no ``` <details>``` parent, so it lost its toggle behavior entirely and rendered as plain, always-visible text. Meanwhile, the inner ```<details>``` had no ```<summary> ``` child of its own, so browsers auto-inserted their default fallback label — the literal word "Details" — as its toggle.

This is exactly why every "Fields renamed" entry showed a generic "▼ Details" toggle.

Fix: reverted to the correct, spec-compliant nesting — <details> as the parent, <summary> as its first child:
```
python"<details><summary>{}</summary>{}</details>".format(summary, details)
```
This restores the intended behavior already used consistently elsewhere in the migration reports: one clickable custom label, with the detailed content folded underneath it.

2. Disclaimer showed the configured limit instead of the actual number of rows displayed

When a caller fetches fewer rows than limit (e.g. data=cr.fetchmany(20) with total=cr.rowcount returning 1546, and the default limit=100), the old code compared total > limit and printed the disclaimer using limit:
```
"The total number of affected records is 1546. This list is showing the first 100 records."
```
<img width="1372" height="134" alt="image" src="https://github.com/user-attachments/assets/13e6eb45-c973-4db3-b3e1-a7961e8ed11a" />

This is inaccurate — only [20 records](https://github.com/odoo/upgrade/commit/2e47e5d37374a80f80c1611507e91f8d511c998d#diff-ecfa011cc2bfd6575bdf0ac7fd7466eb1ace63343ce83dd1a56d37e0de41e3a0R40) were actually rendered, not 100. The message described an internal config value instead of what was actually shown on screen the example is also given in the self report method [here](https://github.com/odoo/upgrade-util/blob/3663104f21e0dfde1bdbc47021335cd11d9f2826/src/util/report.py#L162-L172)

Fix: slice the data once (shown = data[:limit]), and base both the truncation check and the disclaimer text on the actual number of rows shown (shown_count = len(shown)) rather than the raw limit:
```
pythonif total > shown_count:
    disclaimer = "The total number of affected records is {}. This list is showing the first {} records.".format(total, shown_count)
```
Now the message always reflects reality, regardless of whether the caller under-fetched relative to limit.

3. Disclaimer appeared even for tiny lists where it added no value
<img width="1442" height="362" alt="image" src="https://github.com/user-attachments/assets/9876bee8-1580-4f4b-b746-e5117692e279" />

Previously, the disclaimer's first sentence ("The total number of affected records is X.") was shown whenever total was truthy — even for a single record, where mentioning a "total" and "showing first N" is meaningless noise.

Fix: the disclaimer (both sentences, as one unit) is now only generated when the list was genuinely truncated, i.e. total > shown count. If everything fetched is being shown (1 record, 5 records, 20 out of 20, etc.), no disclaimer is added at all.

Improve:-  we can set the default limit 50 if we want to show minimal record. but showing for the single record disclaimer look not good.

With the current patch after migration

<img width="1198" height="234" alt="image" src="https://github.com/user-attachments/assets/7d0119fd-8d13-4ce8-985d-b9905c741ef7" />
<img width="1213" height="152" alt="image" src="https://github.com/user-attachments/assets/5cafe99c-4f7a-49ab-9857-2a3e50c255c6" />
<img width="1205" height="141" alt="image" src="https://github.com/user-attachments/assets/a4f54053-82ae-4b99-beb3-e1fc363894e2" />

UPG:- 4467262