### PR TITLE
[FIX] test_util: fixup cf2ab86

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1849,15 +1849,15 @@ class TestRecords(UnitTestCase):
         eur_xmlid = "base.EUR"
 
         eur = self.env.ref(eur_xmlid)
-        eur.write({"position": "before", "rounding": 0.00001})
+        eur.write({"position": "before", "symbol": "¤"})
         util.flush(eur)
         util.invalidate(eur)
 
-        util.update_record_from_xml(cr, eur_xmlid, fields=["position", "rounding"])
+        util.update_record_from_xml(cr, eur_xmlid, fields=["position", "symbol"])
         util.invalidate(eur)
 
         self.assertEqual(eur.position, "after")  # default = "after", not in <record>
-        self.assertEqual(eur.rounding, 0.01)  # default = 0.01, same value in <record>
+        self.assertEqual(eur.symbol, "€")  # no default, restore <record> value
 
         pubuser_xmlid = "base.public_user"
 


### PR DESCRIPTION
If a currency has already been used for accounting entries, trying to decrease its decimal places fails: https://upgradeci.odoo.com/upgradeci/run/331343.

The test on `pubuser.active` is a better check to ensure that `<record>` values are preserved anyways. So we can just remove the check on eur.rounding.