### PR TITLE
[FIX] base/0.0.0: compute field in SQL

### DIFF
--- a/src/base/0.0.0/post-commercial_partner_id.py
+++ b/src/base/0.0.0/post-commercial_partner_id.py
@@ -1,15 +1,49 @@
-# -*- coding: utf-8 -*-
 from odoo.addons.base.maintenance.migrations import util
 
 
+@util.once("10.0", "20.0")
 def migrate(cr, version):
     # The `commercial_partner_id` field is expected to always be set. Although the column is not marked as `NOT NULL`.
     # Fight the Murphy's Law, and recompute the value on partners with a NULL value.
-    util.recompute_fields(
+    """Ref: https://github.com/odoo/odoo/blob/4cb3090ee829084c2a9260b6d38095cd818678f5/odoo/addons/base/models/res_partner.py#L515
+        if partner.is_company or not partner.parent_id:
+           partner.commercial_partner_id = partner
+        else:
+            partner.commercial_partner_id = partner.parent_id.commercial_partner_id
+    The `is_company` check is gone as of saas~19.1, see odoo/odoo@a0ee79e6."""
+    query = util.format_query(
         cr,
-        "res.partner",
-        ["commercial_partner_id"],
-        query="SELECT id FROM res_partner WHERE commercial_partner_id IS NULL",
-        chunk_size=10000,
-        strategy="commit",
+        """
+        WITH RECURSIVE _commercial_partners_to_set AS (
+              SELECT p.id,
+                     CASE WHEN p.parent_id IS NULL {0} THEN p.id
+                          ELSE p.parent_id
+                     END AS target_id,
+                     p.parent_id IS NULL {0} AS found
+                FROM res_partner p
+               WHERE p.commercial_partner_id IS NULL
+                 AND {{parallel_filter}}
+
+           UNION ALL
+
+              SELECT c.id,
+                     CASE WHEN p.commercial_partner_id IS NOT NULL
+                          THEN p.commercial_partner_id
+                          WHEN p.parent_id IS NULL {0} THEN p.id
+                          ELSE p.parent_id
+                     END AS target_id,
+                     p.commercial_partner_id IS NOT NULL OR p.parent_id IS NULL {0} AS found
+                FROM _commercial_partners_to_set c
+                JOIN res_partner p
+                  ON p.id = c.target_id
+               WHERE NOT c.found
+        )
+        UPDATE res_partner p
+           SET commercial_partner_id = c.target_id
+          FROM _commercial_partners_to_set c
+         WHERE c.id = p.id
+           AND c.found
+        """,
+        util.SQLStr("" if util.version_gte("saas~19.1") else "OR p.is_company IS TRUE"),
     )
+    util.explode_execute(cr, query, table="res_partner", alias="p")


### PR DESCRIPTION
Recomputing **commercial_partner_id** causes the ORM to load huge number of records raising an memory error when computing commercial_partner_id which is fetching is_company for every record Loading millions of records causes a MemoryError. [odoo fix
](https://github.com/odoo/odoo/pull/275295)
As till now the the compute was same in all stable version so we will only run the file once while in migration. may be in future if the computation was changes there we need to update the script accordingly.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/15.0/odoo/modules/registry.py", line 88, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 415, in load_modules
    loaded_modules, processed_modules = load_module_graph(
  File "/home/odoo/src/odoo/15.0/odoo/modules/loading.py", line 227, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/home/odoo/src/odoo/15.0/odoo/modules/migration.py", line 186, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmptz8vmnt0/migrations/base/0.0.0/post-commercial_partner_id.py", line 10, in migrate
    util.recompute_fields(
  File "/tmp/tmptz8vmnt0/migrations/util/orm.py", line 267, in wrapper
    return f(*args, **kwargs)
  File "/tmp/tmptz8vmnt0/migrations/util/orm.py", line 345, in recompute_fields
    cr.commit()
  File "<decorator-gen-9>", line 2, in commit
  File "/home/odoo/src/odoo/15.0/odoo/sql_db.py", line 90, in check
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/15.0/odoo/sql_db.py", line 470, in commit
    self.flush()
  File "/home/odoo/src/odoo/15.0/odoo/sql_db.py", line 109, in flush
    self.transaction.flush()
  File "/home/odoo/src/odoo/15.0/odoo/api.py", line 846, in flush
    env_to_flush['base'].flush()
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 5692, in flush
    self.recompute()
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 6165, in recompute
    process(field)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 6149, in process
    field.recompute(recs)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1265, in recompute
    self.compute_value(record)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1295, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4277, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 88, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 291, in _compute_display_name
    names = dict(self.with_context(**diff).name_get())
  File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 791, in name_get
    name = partner._get_name()
  File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 769, in _get_name
    name = self._get_contact_name(partner, name)
  File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 758, in _get_contact_name
    return "%s, %s" % (partner.commercial_company_name or partner.sudo().parent_id.name, name)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1080, in __get__
    self.recompute(record)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1273, in recompute
    self.compute_value(recs)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1295, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4277, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 88, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 351, in _compute_commercial_company_name
    p = partner.commercial_partner_id
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 2620, in __get__
    return super().__get__(records, owner)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1080, in __get__
    self.recompute(record)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1265, in recompute
    self.compute_value(record)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1295, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 4277, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 88, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/15.0/odoo/addons/base/models/res_partner.py", line 343, in _compute_commercial_partner
    if partner.is_company or not partner.parent_id:
  File "/home/odoo/src/odoo/15.0/odoo/fields.py", line 1109, in __get__
    recs._fetch_field(self)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3292, in _fetch_field
    self._read(fnames)
  File "/home/odoo/src/odoo/15.0/odoo/models.py", line 3389, in _read
    self.env.cache.update(fetched, field, values)
  File "/home/odoo/src/odoo/15.0/odoo/api.py", line 913, in update
    field_cache.update(zip(records._ids, values))
MemoryError
```

As the odoo generic will not merge in 15.0 as its not stable version :- https://github.com/odoo/odoo/pull/275295#issuecomment-5105265513
so we need to handle in migration only

Some commits which confirm:- https://github.com/odoo/odoo/pull/279976#issuecomment-5167372081
checkd the scirpt 

I have also test the soln with random record 

UPG:- 4467262