### PR TITLE
[IMP] remove_records

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -472,12 +472,12 @@ def remove_records(cr, model, ids):
         if not ir.company_dependent_comodel:
             query = format_query(
                 cr,
-                "DELETE FROM {} WHERE {} AND {} IN %s",
+                "DELETE FROM {} WHERE {} AND {} = %s",
                 ir.table,
                 ir.model_filter(),
                 ir.res_id,
             )
-            explode_execute(cr, cr.mogrify(query, [model, ids]).decode(), table=ir.table)
+            parallel_execute(cr, [cr.mogrify(query, [model, id_]).decode() for id_ in ids])
         elif ir.company_dependent_comodel == model:
             json_path = cr.mogrify(
                 "$.* ? ({})".format(" || ".join(["@ == %s"] * len(ids))),


### PR DESCRIPTION
Using `explode_execute` for deleting indirect references is actually counter-productive when the list of references (`res_id` column) is small. We can just split per id as we can assume there will have an index on the res_model/res_id columns.