### PR TITLE
[FIX] util/orm: Fix non store field issue

### DIFF
--- a/src/util/orm.py
+++ b/src/util/orm.py
@@ -571,6 +571,32 @@ class iter_browse(object):
         )
 
 
+def _patch_unsearchable_manual_fields(env, updated_field_ids):
+    if not updated_field_ids:
+        return
+
+    env.cr.execute(
+        """
+        SELECT name, model
+          FROM ir_model_fields
+         WHERE store = false
+           AND id IN %s
+        """,
+        [tuple(updated_field_ids)],
+    )
+
+    def _search_field_dummy(self, operator, value):
+        return [(1, "=", 1)]
+
+    for field_name, model_name in env.cr.fetchall():
+        if model_name not in env:
+            continue
+        Model = env[model_name]
+        field = Model._fields.get(field_name)
+        if field is not None and not field.search:
+            field.search = _search_field_dummy
+
+
 @contextmanager
 def custom_module_field_as_manual(env, rollback=True, do_flush=False):
     """
@@ -826,6 +852,11 @@ def custom_module_field_as_manual(env, rollback=True, do_flush=False):
             env.registry._setup_models__ if hasattr(env.registry, "_setup_models__") else env.registry.setup_models
         )
         setup_models(env.cr)
+
+    # 4.1 Non-stored fields with no `search` method will otherwise raise an
+    # ValueError (not stored, cannot convert to SQL).
+    if version_gte("19.0"):
+        _patch_unsearchable_manual_fields(env, updated_field_ids)
 
     # 5. Do the operation.
     yield


### PR DESCRIPTION
Since 18.3, domain resolution goes strictly through ` _search`

```
    domain.optimize_full(model)
    if not domain.is_true():
        query.add_where(domain._to_sql(self, self._table, query))
```
[domain]: https://github.com/odoo/odoo/blob/2f0f8e5e00685129b5bbe954117bc9f80a568e88/odoo/orm/models.py#L5365-L5371

optimize_full() leaves a leaf untouched when the field has no `search=` defined, so `_to_sql()` calls `field.to_sql()` directly. For non-stored fields this now raises:
```
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5256, in _order_to_sql
    term = self._order_field_to_sql(alias, field_name, sql_direction, sql_nulls, query)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5315, in _order_field_to_sql
    sql_field = self._field_to_sql(alias, field_name, query)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 2930, in _field_to_sql
    sql = field.to_sql(self, alias)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields_textual.py", line 395, in to_sql
    sql_field = super().to_sql(model, alias)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1216, in to_sql
    raise ValueError(f"Cannot convert {self} to SQL because it is not stored")
 ValueError: Cannot convert photovoltaics.installer.name to SQL because it is not stored
```

Previously (pre-18.3), such leaves were treated as always-true instead of raising:

https://github.com/odoo/odoo/blob/d9c06a66356dd9d5a50821b8cde6194967353c18/odoo/osv/expression.py#L1180-L1187

Since we don't always know if a custom/third-party field is stored or searchable, assign a dummy `search=` returning an always-true leaf (e.g. [(1, '=', 1)]). This makes optimize_full() resolve the domain to is_true() before _to_sql() runs, restoring the old behavior and avoiding the ValueError.

upg- 4578773
