### PR TITLE
[FIX] util/misc: allow None in util.once

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -2626,6 +2626,16 @@ class TestOnce(UnitTestCase):
             # Interval entirely outside the upgrade path: never fire
             ("16.0", "saas~17.2", "saas~17.4", [("17.0", False), ("18.0", False)]),
             ("16.0", "18.0", "19.0", [("17.0", False)]),
+            # An open bound (None) may fall outside the [source, target] window: the other bound then
+            # defaults to a version on the wrong side of it.
+            # Lower bound after the target, the whole path is before the interval.
+            ("16.0", "saas~19.4", None, [("17.0", False), ("18.0", False), ("19.0", False)]),
+            # Same, for an intermediate step of that upgrade, run with its own source/target.
+            ("16.0", "saas~19.4", None, [("17.0", False)]),
+            ("17.0", "saas~19.4", None, [("18.0", False)]),
+            # Upper bound before the source, the whole path is after the interval.
+            ("18.0", None, "17.0", [("19.0", False)]),
+            ("saas~18.2", None, "saas~17.4", [("19.0", False), ("saas~19.3", False)]),
         ]
     )
     def test_once(self, source, lower, upper, steps_and_expected):

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -208,9 +208,10 @@ class once(object):
         s, t = parse_version(_SOURCE_VERSION), parse_version(_TARGET_VERSION)
         assert s <= t, "check source and target env vars"
 
+        if lower is not None and upper is not None and parse_version(lower) > parse_version(upper):
+            raise SleepyDeveloperError("invalid interval: lower={!r} > upper={!r}".format(lower, upper))
         a = s if lower is None else parse_version(lower)
         b = t if upper is None else parse_version(upper)
-        assert a <= b, "invalid interval"
 
         s_maj = int(_SOURCE_VERSION.replace("saas~", "").replace("saas-", "").split(".", 1)[0])
         t_parts = _TARGET_VERSION.replace("saas~", "").replace("saas-", "").split(".", 1)


### PR DESCRIPTION
`None` as source or target version in `util.once` is a legitimate value that corresponds to `util.version_gte(..)`.
The [previous block](https://github.com/odoo/upgrade-util/blob/cb9ef521af323981f2363b94faa2679c2a639b6a/src/util/misc.py#L200-L201) already treats it as such.

Previous implementation failed the assertion: for instance an upgrade from 16.0 to 19.0, running `util.once('saas~19.4', None)` at the `17.0` step of the upgrade would mean `a=saas~19.4` and `b=17.0`, thus failing `assert a <= b`.

Required for https://github.com/odoo/upgrade/pull/11027, as well as a fix for https://github.com/odoo/upgrade/blob/cdfe501f2fe8b49edcd1a7e9377eb55801a62e1e/migrations/accountant_knowledge/0.0.0/end-article-knowledge.py#L10.