### PR TITLE
[FIX] util/pg: fix obtaining m2m

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -1258,6 +1258,50 @@ class TestPG(UnitTestCase):
         self.assertEqual("res_groups_res_users_rel", auto_generated_m2m_table_name)
         self.assertTrue(util.table_exists(cr, auto_generated_m2m_table_name))
 
+    def test_get_m2m_on(self):
+        cr = self.env.cr
+
+        cr.execute(
+            """
+            CREATE TABLE _upg_test_m2m_main (id serial PRIMARY KEY);
+            CREATE TABLE _upg_test_m2m_other (id serial PRIMARY KEY);
+
+            -- a typical, valid m2m table
+            CREATE TABLE _upg_test_m2m_rel (
+                main_id int REFERENCES _upg_test_m2m_main,
+                other_id int REFERENCES _upg_test_m2m_other
+            );
+
+            -- m2m table whose columns are covered by more than one FK constraint
+            CREATE TABLE _upg_test_m2m_dup_rel (
+                main_id int REFERENCES _upg_test_m2m_main,
+                other_id int REFERENCES _upg_test_m2m_other
+            );
+            ALTER TABLE _upg_test_m2m_dup_rel
+                  ADD CONSTRAINT _upg_test_m2m_dup_rel_main_id_fkey2
+                      FOREIGN KEY (main_id) REFERENCES _upg_test_m2m_main,
+                  ADD CONSTRAINT _upg_test_m2m_dup_rel_other_id_fkey2
+                      FOREIGN KEY (other_id) REFERENCES _upg_test_m2m_other;
+
+            -- m2m table that once had a third column
+            CREATE TABLE _upg_test_m2m_dropped_rel (
+                main_id int REFERENCES _upg_test_m2m_main,
+                other_id int REFERENCES _upg_test_m2m_other,
+                gone int
+            );
+            ALTER TABLE _upg_test_m2m_dropped_rel DROP COLUMN gone;
+            """
+        )
+
+        self.assertEqual(
+            sorted(util.get_m2m_on(cr, "_upg_test_m2m_main")),
+            [
+                ("_upg_test_m2m_dropped_rel", "main_id", "other_id", "_upg_test_m2m_other"),
+                ("_upg_test_m2m_dup_rel", "main_id", "other_id", "_upg_test_m2m_other"),
+                ("_upg_test_m2m_rel", "main_id", "other_id", "_upg_test_m2m_other"),
+            ],
+        )
+
     def test_rename_m2m(self):
         cr = self.env.cr
 

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -1797,37 +1797,42 @@ def get_m2m_on(cr, table):
                 ON a.attrelid = t.oid
              WHERE t.relkind = 'r'
                AND a.attnum > 0
+               AND NOT a.attisdropped
           GROUP BY t.oid
             HAVING count(*) = 2
+        ), fks AS (
+            SELECT c.conrelid,
+                   c.conkey[1] AS attnum, -- c.conkey references pg_attribute.attnum
+                   c.confrelid
+              FROM pg_constraint c
+              JOIN two_cols tc
+                ON tc.oid = c.conrelid
+             WHERE c.contype = 'f'
+               AND array_length(c.conkey, 1) = 1
+          GROUP BY c.conrelid, c.conkey[1], c.confrelid
         )
         SELECT t.relname, a1.attname, a2.attname, other_table.relname
           FROM pg_class t
           JOIN two_cols tc
             ON t.oid = tc.oid
 
+          JOIN fks f1
+            ON f1.conrelid = t.oid
           JOIN pg_attribute a1
             ON a1.attrelid = t.oid
-           AND a1.attnum > 0
-          JOIN pg_constraint c1
-            ON c1.conrelid = t.oid
-           AND c1.contype = 'f'
-           AND a1.attnum = any(c1.conkey)
-           AND array_length(c1.conkey, 1) = 1
+           AND a1.attnum = f1.attnum
 
+          JOIN fks f2
+            ON f2.conrelid = t.oid
+           AND f2.attnum != f1.attnum
           JOIN pg_attribute a2
             ON a2.attrelid = t.oid
-           AND a2.attnum > 0
-           AND a1.attnum != a2.attnum
-          JOIN pg_constraint c2
-            ON c2.conrelid = t.oid
-           AND c2.contype = 'f'
-           AND a2.attnum = any(c2.conkey)
-           AND array_length(c1.conkey, 1) = 1
+           AND a2.attnum = f2.attnum
 
           JOIN pg_class the_table
-            ON c1.confrelid = the_table.oid
+            ON f1.confrelid = the_table.oid
           JOIN pg_class other_table
-            ON c2.confrelid = other_table.oid
+            ON f2.confrelid = other_table.oid
          WHERE the_table.relkind = 'r'
            AND the_table.relname = %s
            AND other_table.relname != the_table.relname


### PR DESCRIPTION
Fixes the following issues with the query returning m2m:
- Duplicate constraints responsible for returning the same m2m more than once.
Now we first gather fk constraints in a CTE that ensures there are no dupes, and only then we do the two `JOIN`s on `pg_attribute` to obtain their columns.
- Typo in the a2 `JOIN` referencing `c1.conkey`, instead of `c2.conkey`.
Made irrelevant after refactoring. Now there is only one place where we check `AND array_length(c.conkey, 1) = 1`.
- Add `AND NOT a.attisdropped` to exclude dropped columns.
Dropped columns remain in `pg_attribute` flagged as `attisdropped=True`, leaving room for erroneously fetching them when `JOIN`ining `pg_attribute`.