### PR TITLE
[FIX] base/0.0.0: smarter recompute

### DIFF
--- a/src/base/0.0.0/post-commercial_partner_id.py
+++ b/src/base/0.0.0/post-commercial_partner_id.py
@@ -1,10 +1,62 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.base.maintenance.migrations import util
 
+_logger = util.getLogger(__name__)
+
 
 def migrate(cr, version):
+    cr.execute("SELECT 1 FROM res_partner WHERE commercial_partner_id IS NULL LIMIT 1")
+    if cr.rowcount:
+        _migrate(cr)
+
+
+def _migrate(cr):
     # The `commercial_partner_id` field is expected to always be set. Although the column is not marked as `NOT NULL`.
     # Fight the Murphy's Law, and recompute the value on partners with a NULL value.
+    query = """
+        WITH RECURSIVE top_level_candidates AS (
+            SELECT id,
+                   commercial_partner_id IS NULL AS is_candidate
+              FROM res_partner
+             WHERE parent_id IS NULL
+
+             UNION ALL
+
+            SELECT c.id,
+                   c.commercial_partner_id IS NULL
+              FROM top_level_candidates p
+              JOIN res_partner c
+                ON c.parent_id = p.id
+             WHERE NOT p.is_candidate
+        ), top_level_candidates_subtrees AS (
+                -- every node is in its own subtree
+            SELECT id AS root_id,
+                   id
+              FROM top_level_candidates
+             WHERE is_candidate
+             UNION ALL
+                -- add nodes to subtree
+            SELECT p.root_id,
+                   c.id
+              FROM top_level_candidates_subtrees p
+              JOIN res_partner c
+                ON c.parent_id = p.id
+        )
+        SELECT root_id
+          FROM top_level_candidates_subtrees
+      GROUP BY root_id
+        HAVING COUNT(*) > 10000
+    """
+    _logger.info("Computing `commercial_partner_id` for big entities")
+    util.recompute_fields(
+        cr,
+        "res.partner",
+        ["commercial_partner_id"],
+        query=query,
+        chunk_size=1,
+        strategy="commit",
+    )
+    _logger.info("Computing `commercial_partner_id` for the rest")
     util.recompute_fields(
         cr,
         "res.partner",


### PR DESCRIPTION
`commercial_patner_id` is a recursive field. If we trigger the
computation in a parent record, then all its children and further
descendants will get recomputed. This is problematic for entities
(companies) with many child partners (employees or sub-companies). For
example, if we have 10 records with 10K+ descendants and all 10 get
recomputed in the same batch, it would potentially recompute 100K+
records. This is what's happening in a currently failing upgrade that
ends up in a `MemoryError`.

Trying to compute the value in SQL necessitates verification in all
involved versions. Even on a single version it risks a desync with other
fields (like computed names).

The solution is to recompute the field in a smarter way. We can find
first the topmost disjoint ancestors with 10K+ children. Issue a
recompute for each individually. Then proceed with what remains.

Technically, in the proposed patch we first compute the number of
descendants of current node. This serves to pick candidates with 10k+
descendants for single processing. Among the candidates we then keep
those without commercial partner and without any other picked candidate
in its ancestors. Once the valid candidates are chosen and recomputed
individually we let the rest be computed as before.

This approach relies in some observations:
* The depth of partners tree is expected to be relatively shallow.
* The number of entities with 10K partners shouldn't be that many.
* Thus we don't expect a partner with many descendants to have more than
  one big subtree (that would mean two different 10K+ employees
  companies with the same parent one --rare).

In any case the approach works for the currently failing case.
upg-4449419

```
2026-08-18 13:20:19,344 23 INFO afu_4449419_15.0 odoo.modules.migration: module base: Running migration [0.0.0>] post-commercial_partner_id
2026-08-18 13:20:19,344 23 INFO afu_4449419_15.0 odoo.upgrade.base.0.0.0.post-commercial_partner_id: Computing `commercial_partner_id` for big entities
2026-08-18 13:20:55,466 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: Computing fields ['commercial_partner_id'] of 'res.partner' on 99 records
2026-08-18 13:22:02,629 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [  7.07%]    7/99 res.partner processed in 0:01:07.162441 (total estimated time: 0:15:49.868808)
2026-08-18 13:23:09,342 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 13.13%]   13/99 res.partner processed in 0:02:13.875625 (total estimated time: 0:16:59.514375)
2026-08-18 13:24:13,223 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 19.19%]   19/99 res.partner processed in 0:03:17.756615 (total estimated time: 0:17:10.416047)
2026-08-18 13:25:15,635 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 24.24%]   24/99 res.partner processed in 0:04:20.169048 (total estimated time: 0:17:53.197323)
2026-08-18 13:26:23,997 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 31.31%]   31/99 res.partner processed in 0:05:28.530532 (total estimated time: 0:17:29.178151)
2026-08-18 13:27:26,094 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 36.36%]   36/99 res.partner processed in 0:06:30.627813 (total estimated time: 0:17:54.226486)
2026-08-18 13:28:31,586 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 42.42%]   42/99 res.partner processed in 0:07:36.119937 (total estimated time: 0:17:55.139851)
2026-08-18 13:29:34,593 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 48.48%]   48/99 res.partner processed in 0:08:39.126281 (total estimated time: 0:17:50.697955)
2026-08-18 13:30:42,650 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 54.55%]   54/99 res.partner processed in 0:09:47.184054 (total estimated time: 0:17:56.504099)
2026-08-18 13:31:56,407 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 60.61%]   60/99 res.partner processed in 0:11:00.940669 (total estimated time: 0:18:10.552104)
2026-08-18 13:33:08,995 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 66.67%]   66/99 res.partner processed in 0:12:13.528805 (total estimated time: 0:18:20.293208)
2026-08-18 13:34:13,285 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 71.72%]   71/99 res.partner processed in 0:13:17.818645 (total estimated time: 0:18:32.451350)
2026-08-18 13:35:23,066 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 76.77%]   76/99 res.partner processed in 0:14:27.600076 (total estimated time: 0:18:50.163257)
2026-08-18 13:36:36,956 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 80.81%]   80/99 res.partner processed in 0:15:41.490037 (total estimated time: 0:19:25.093921)
2026-08-18 13:37:43,505 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 85.86%]   85/99 res.partner processed in 0:16:48.039054 (total estimated time: 0:19:34.069016)
2026-08-18 13:38:59,567 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 90.91%]   90/99 res.partner processed in 0:18:04.100716 (total estimated time: 0:19:52.510788)
2026-08-18 13:40:05,389 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 94.95%]   94/99 res.partner processed in 0:19:09.922940 (total estimated time: 0:20:11.089054)
2026-08-18 13:41:08,636 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 98.99%]   98/99 res.partner processed in 0:20:13.170033 (total estimated time: 0:20:25.549319)
2026-08-18 13:41:22,897 23 INFO afu_4449419_15.0 odoo.upgrade.base.0.0.0.post-commercial_partner_id: Computing `commercial_partner_id` for the rest
2026-08-18 13:41:23,206 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: Computing fields ['commercial_partner_id'] of 'res.partner' on 42106 records
2026-08-18 13:42:27,309 23 INFO afu_4449419_15.0 odoo.upgrade.util.orm: [ 57.58%]      3/5 res.partner 10000-bucket processed in 0:01:04.102544 (total estimated time: 0:01:51.335435)
2026-08-18 13:42:45,417 23 INFO afu_4449419_15.0 odoo.modules.migration: module base: Running migration [0.0.0>] post-currency-symbol
```
