### PR TITLE
[FIX] util/fields: skip stale related path when removing field

### DIFF
--- a/src/base/tests/test_util.py
+++ b/src/base/tests/test_util.py
@@ -530,6 +530,16 @@ class TestRemoveFieldDomains(UnitTestCase):
         domain = [("updated", "=", 0)]
         self._test_remove_field(domain, domain, update_references=False)
 
+    @parametrize([(False, [("added", "=", 0)]), (True, [TRUE_LEAF])])
+    def test_remove_field_related_path(self, remove_target_first, expected):
+        cr = self.env.cr
+        cr.execute(
+            "UPDATE ir_model_fields SET related = 'added' WHERE model = 'base.module.update' AND name = 'updated'"
+        )
+        if remove_target_first:
+            util.remove_field(cr, "base.module.update", "added")
+        self._test_remove_field([("updated", "=", 0)], expected)
+
 
 class TestIrExports(UnitTestCase):
     def setUp(self):

--- a/src/util/fields.py
+++ b/src/util/fields.py
@@ -246,6 +246,10 @@ def remove_field(
             cr.execute("SELECT related FROM ir_model_fields WHERE model=%s AND name=%s", [model, fieldname])
             if cr.rowcount:
                 related = cr.fetchone()[0]
+            if related:  # `related` could be using stale references to removed/invalid fields
+                path = related.split(".")
+                if len(resolve_model_fields_path(cr, model, path)) != len(path):
+                    related = None
 
         if related:
             update_field_usage(cr, model, fieldname, related, skip_inherit=skip_inherit)


### PR DESCRIPTION
`remove_field` blindly reused a field's `related` path to redirect domain adaptation, even if the path's target had already been removed by an earlier `remove_field` call (e.g. removing a related field before its target across two models). This produced domains referencing non-existing fields, breaking at runtime.

Validate the path with `resolve_model_fields_path` before using it; fall back to plain domain cleanup if it no longer resolves.

usecase: https://github.com/odoo/upgrade/pull/11066