### PR TITLE
[FIX] util/pg: fix m2m doesn't exist

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -1588,7 +1588,6 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
                 UPDATE ir_model_fields
                    SET relation_table = %s
                  WHERE relation_table = %s
-                   AND state = 'manual'
                 """,
                 [m2m_table, orig_m2m_table],
             )
@@ -1646,7 +1645,6 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
                    SET column1 = %s
                  WHERE relation_table = %s
                    AND column1 = %s
-                   AND state = 'manual'
                 """,
                 [new_col, m2m_table, old_col],
             )
@@ -1656,7 +1654,6 @@ def update_m2m_tables(cr, old_table, new_table, ignored_m2ms=()):
                    SET column2 = %s
                  WHERE relation_table = %s
                    AND column2 = %s
-                   AND state = 'manual'
                 """,
                 [new_col, m2m_table, old_col],
             )


### PR DESCRIPTION
When a custom field's relation model is renamed,
the relation model is updated in ir_model_fields
regardless of whether the field state is manual [condition].

However, when renaming the model, the related
M2M tables and relation columns were updated
only for manual fields. This could leave the
relation inconsistent.

The inconsistency could later cause the mock
crawl to fail, as custom module fields are marked
as manual during the crawl.

Remove the manual condition so that relation
tables and columns are updated for all fields,
preventing upgrade requests from failing due to
inconsistent relation. 


[condition]: https://github.com/odoo/upgrade-util/blob/ce76f4d2dafd6fe4c3b859548b9a2f8b5bdea408/src/util/models.py#L346

```py
('hr_payroll_co.hr_contribution_form_menu_act', 362, 'Recursos Humanos > Autoliquidación > Planillas de aportes', 485):
 Traceback (most recent call last):
   File "/tmp/tmpfaiwjdd5/migrations/base/tests/test_mock_crawl.py", line 346, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpfaiwjdd5/migrations/base/tests/test_mock_crawl.py", line 377, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpfaiwjdd5/migrations/base/tests/test_mock_crawl.py", line 537, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpfaiwjdd5/migrations/base/tests/test_mock_crawl.py", line 570, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3489, in read
    self._origin.fetch(fields)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3812, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3940, in _fetch_query
    field.read(fetched)
   File "/home/odoo/src/odoo/19.0/odoo/orm/fields_relational.py", line 1396, in read
    for id1, id2 in records.env.execute_query(query.select(sql_id1, sql_id2)):
   File "/home/odoo/src/odoo/19.0/odoo/orm/environments.py", line 534, in execute_query
    self.cr.execute(query)
   File "/home/odoo/src/odoo/19.0/odoo/tests/test_cursor.py", line 79, in execute
    return self._cursor.execute(*args, **kwargs)
   File "/home/odoo/src/odoo/19.0/odoo/sql_db.py", line 440, in execute
    self._obj.execute(query, params)
 psycopg2.errors.UndefinedTable: relation "hr_contribution_form_hr_contract_rel" does not exist
LINE 1: ...ract_rel"."hr_contract_id" FROM "hr_version" JOIN "hr_contri...
```

upg-4614063