### PR TITLE
[IMP] util/domains: batch column check

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -35,7 +35,14 @@ from .const import NEARLYWARN
 from .helpers import _dashboard_actions, _validate_model, resolve_model_fields_path
 from .inherit import for_each_inherit
 from .misc import SelfPrintEvalContext, ast_unparse, literal_replace, safe_eval, version_gte
-from .pg import SQLStr, column_exists, format_query, get_value_or_en_translation, table_exists
+from .pg import (
+    SQLStr,
+    _existing_columns,
+    column_exists,
+    format_query,
+    get_value_or_en_translation,
+    table_exists,
+)
 from .records import edit_view
 
 # python3 shims
@@ -220,8 +227,9 @@ def _get_domain_fields(cr):
         DomainField("loyalty_reward", "discount_product_domain", "'product.product'"),
     ]
 
+    existing = _existing_columns(cr, ((df.table, df.domain_column) for df in result))
     for df in result:
-        if column_exists(cr, df.table, df.domain_column):
+        if (df.table, df.domain_column) in existing:
             yield df
 
 

--- a/src/util/indirect_references.py
+++ b/src/util/indirect_references.py
@@ -2,7 +2,7 @@
 import collections
 
 from .helpers import model_of_table, table_of_model
-from .pg import SQLStr, column_exists, table_exists
+from .pg import SQLStr, _existing_columns, table_exists
 
 
 class IndirectReference(
@@ -102,25 +102,33 @@ INDIRECT_REFERENCES = [
 
 
 def indirect_references(cr, bound_only=False):
+    columns_to_check = {("ir_model_fields", "company_dependent")} | {
+        (ir.table, column)
+        for ir in INDIRECT_REFERENCES
+        for column in (ir.res_id, ir.res_model, ir.res_model_id)
+        if column
+    }
+    existing = _existing_columns(cr, columns_to_check)
+
     for ir in INDIRECT_REFERENCES:
         if bound_only and not ir.res_id:
             continue
-        if ir.res_id and not column_exists(cr, ir.table, ir.res_id):
+        if ir.res_id and (ir.table, ir.res_id) not in existing:
             continue
 
         # some `res_model/res_model_id` combination may change between
         # versions (i.e. rating_rating.res_model_id was added in saas~15).
         # we need to verify existence of columns before using them.
-        if ir.res_model and not column_exists(cr, ir.table, ir.res_model):
+        if ir.res_model and (ir.table, ir.res_model) not in existing:
             ir = ir._replace(res_model=None)  # noqa: PLW2901
-        if ir.res_model_id and not column_exists(cr, ir.table, ir.res_model_id):
+        if ir.res_model_id and (ir.table, ir.res_model_id) not in existing:
             ir = ir._replace(res_model_id=None)  # noqa: PLW2901
         if not ir.res_model and not ir.res_model_id:
             continue
 
         yield ir
 
-    if column_exists(cr, "ir_model_fields", "company_dependent"):
+    if ("ir_model_fields", "company_dependent") in existing:
         cr.execute(
             """
             SELECT model, name, relation

--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -622,6 +622,33 @@ def column_exists(cr, table, column):
     return bool(cr.rowcount)
 
 
+def _existing_columns(cr, pairs):
+    pairs = set(pairs)
+    if not pairs:
+        return set()
+
+    result = {pair for pair in pairs if _COLUMNS.get(pair)}
+    # the pairs shortcut as non-existing are known, no need to look for them
+    to_query = [pair for pair in pairs if _COLUMNS.get(pair) is None]
+    if to_query:
+        for table, _column in to_query:
+            _validate_table(table)
+        cr.execute(
+            """
+            SELECT c.relname,
+                   a.attname
+              FROM pg_attribute a
+              JOIN pg_class c
+                ON a.attrelid = c.oid
+             WHERE NOT a.attisdropped
+               AND (c.relname, a.attname) IN %s
+            """,
+            [tuple(to_query)],
+        )
+        result.update(cr.fetchall())
+    return result
+
+
 def column_type(cr, table, column, sized=False):
     """
     Return the type of a column, if it exists.

--- a/src/util/snippets.py
+++ b/src/util/snippets.py
@@ -1,3 +1,4 @@
+import collections
 import concurrent
 import contextlib
 import enum
@@ -20,7 +21,7 @@ from .const import NEARLYWARN
 from .helpers import table_of_model
 from .misc import log_progress, make_pickleable_callback, version_gte
 from .modules import INSTALLED_MODULE_STATES
-from .pg import SQLStr, column_exists, column_type, format_query, get_max_workers, table_exists
+from .pg import SQLStr, _existing_columns, column_type, format_query, get_max_workers
 
 _logger = logging.getLogger(__name__)
 utf8_parser = html.HTMLParser(encoding="utf-8")
@@ -148,24 +149,44 @@ def _html_fields(cr, modules):
                AND f.model NOT IN ('mail.message', 'mail.mail')
           GROUP BY f.model, f.name
         )
-        SELECT model, array_agg(name ORDER BY name)
+        SELECT model, array_agg(name)
           FROM _fields
       GROUP BY model
-      ORDER BY model
         """,
         SQLStr(module_cte),
         SQLStr(extra_join),
     )
 
     cr.execute(query, {"root_modules": modules, "states": INSTALLED_MODULE_STATES})
-    for model, columns in cr.fetchall():
-        table = table_of_model(cr, model)
-        if not table_exists(cr, table):
-            # an SQL VIEW
-            continue
-        existing_columns = [column for column in columns if column_exists(cr, table, column)]
-        if existing_columns:
-            yield table, existing_columns
+    data = {table_of_model(cr, model): columns for model, columns in cr.fetchall()}
+    if not data:
+        return
+
+    # the models backed by an SQL VIEW are skipped, only keep the base tables
+    cr.execute(
+        """
+        SELECT c.relname
+          FROM pg_class c
+          JOIN pg_namespace n
+            ON n.oid = c.relnamespace
+         WHERE c.relname IN %s
+           AND c.relkind IN ('r', 'p')
+           AND n.nspname = current_schema
+        """,
+        [tuple(data)],
+    )
+    valid_tables = {table for (table,) in cr.fetchall()}
+
+    existing = _existing_columns(
+        cr, ((table, column) for table, columns in data.items() if table in valid_tables for column in columns)
+    )
+    table_columns = collections.defaultdict(list)
+    for table, column in existing:
+        table_columns[table].append(column)
+
+    # sorted output for determinism
+    for table in sorted(table_columns):
+        yield table, sorted(table_columns[table])
 
 
 def html_fields(cr, scope=FieldScope.ALL):


### PR DESCRIPTION
`adapt_domains` is called for every field removal, potentially multiple
times (inherits). Each possible domain field needs a check of their
column. This compound to thousands of queries on each upgrade. Here we
propose to batch the columns check.

Numbers for an upgrade 19->master:
| DB | baseline queries | baseline `column_exists` | batched queries | batched `column_exists` | delta queries | delta `column_exists` |
|---|---|---|---|---|---|---|
| web | 142236 | 39952 | 131293 | 26632 | -10943 (-7.7%) | -13320 (-33.3%) |
| heavy | 225223 | 64104 | 196640 | 32654 | -28583 (-12.7%) | -31450 (-49.1%) |

- **DB web**: `website_sale`, `website_blog`, `website_event`, `calendar` -> 118 modules
- **DB heavy**: `account`, `mrp`, `l10n_be_hr_payroll`, `crm`, `calendar` -> 136 modules
