### PR TITLE
[FIX] util/record: remove model data of cascade records

### DIFF
--- a/src/util/records.py
+++ b/src/util/records.py
@@ -643,6 +643,28 @@ def remove_records(cr, model, ids):
                 remove_records(cr, inh.model, [rid for (rid,) in cr.fetchall()])
 
     table = table_of_model(cr, model)
+    m2m_tables = [m[0] for m in get_m2m_on(cr, table)]
+    delete_queries = []
+    for fk_tbl, fk_col, _, fk_act in get_fk(cr, table, quote_ident=False):
+        if not (fk_act == "c" and fk_tbl not in m2m_tables):
+            continue
+        delete_queries.append(
+            cr.mogrify(
+                format_query(
+                    cr,
+                    """
+                        DELETE FROM ir_model_data
+                              WHERE model = %s
+                                AND res_id IN (SELECT id FROM {fk_tbl} WHERE {fk_col} IN %s)
+                    """,
+                    fk_tbl=fk_tbl,
+                    fk_col=fk_col,
+                ),
+                [model_of_table(cr, fk_tbl), ids],
+            ),
+        )
+    if delete_queries:
+        parallel_execute(cr, delete_queries)
     base_query = format_query(cr, "DELETE FROM {} WHERE id IN %s", table)
     parallel_execute(
         cr,


### PR DESCRIPTION
- When records are deleted, cascade-linked records are also deleted.
This may leave behind the ir_model_data entries in the database.
This then triggers the records removal again when the ORM cleans up
non-loaded references (after all end- scripts). This pollutes the logs
with useless info.

- before fix:
```py
(Pdb) cr.execute("select count(*) from account_report_expression where report_line_id in (60, 61, 59, 57, 58, 56, 55)")
(Pdb) cr.fetchone()
(0,)
(Pdb) cr.execute("select count(*) from ir_model_data imd left join account_report_expression are on imd.res_id = are.id where model='account.report.expression' and are.id is null")
(Pdb) cr.fetchone()
(34,)
```
- as a short note:
```py
2026-08-27 12:26:05,543 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 80@account.report.expression (account_reports.unreconciled_last_statement_payments_forced_currency_amount)
2026-08-27 12:26:05,543 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 79@account.report.expression (account_reports.unreconciled_last_statement_payments_amount)
2026-08-27 12:26:05,544 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 78@account.report.expression (account_reports.unreconciled_last_statement_payments_currency)
2026-08-27 12:26:05,544 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 77@account.report.expression (account_reports.unreconciled_last_statement_payments_forced_currency_amount_currency)
2026-08-27 12:26:05,544 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 76@account.report.expression (account_reports.unreconciled_last_statement_payments_amount_currency)
2026-08-27 12:26:05,545 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 75@account.report.expression (account_reports.unreconciled_last_statement_payments_label)
2026-08-27 12:26:05,546 339679 INFO test_19 odoo.addons.base.models.ir_model: Deleting 74@account.report.expression (account_reports.unreconciled_last_statement_payments_date)
```
- after fix:
```py
(Pdb) cr.execute("select count(*) from account_report_expression where report_line_id in (60, 61, 59, 57, 58, 56, 55)")
(Pdb) cr.fetchone()
(0,)
(Pdb) cr.execute("select count(*) from ir_model_data imd left join account_report_expression are on imd.res_id = are.id where model='account.report.expression' and are.id is null")
(Pdb) cr.fetchone()
(0,)
```