### PR TITLE
[FIX] util/domains.py: handle removed ir.actions.server model_name

### DIFF
--- a/src/util/domains.py
+++ b/src/util/domains.py
@@ -152,12 +152,28 @@ def _get_domain_fields(cr):
             DomainField(
                 "base_automation",
                 "filter_domain",
-                "(SELECT model_name FROM ir_act_server WHERE id = t.action_server_id)",
+                """
+                (
+                    SELECT m.model
+                      FROM ir_act_server AS act
+                      JOIN ir_model AS m
+                        ON m.id = act.model_id
+                     WHERE act.id = t.action_server_id
+                )
+                """,
             ),
             DomainField(
                 "base_automation",
                 "filter_pre_domain",
-                "(SELECT model_name FROM ir_act_server WHERE id = t.action_server_id)",
+                """
+                (
+                    SELECT m.model
+                      FROM ir_act_server AS act
+                      JOIN ir_model AS m
+                        ON m.id = act.model_id
+                     WHERE act.id = t.action_server_id
+                )
+                """,
             ),
         ]
     else:


### PR DESCRIPTION
The `ir_act_server.model_name` column is [removed] during the upgrade, but [adapt_domains] can still process domain fields from `base_automation` afterwards.

[_get_domain_fields] was still generating queries that referenced `ir_act_server.model_name`, causing `UndefinedColumn` errors when `remove_field()` triggered [domain adaptation] for fields such as `res.partner.title`.

Handle the removal of `model_name` in domain field by retrieving the model name from the `ir_model` table using `model_id`, ensuring that domain adaptation does not query a column that no longer exists.

[removed]: https://github.com/odoo/upgrade/blob/279cbd2eb70f5342fc57b157d443b28c081e0f0e/migrations/base/saas~18.1.1.3/pre-migrate.py#L6
[adapt_domains]: https://github.com/odoo/upgrade-util/blob/3d94a29924f407cdb2c88e2e9fd770746bb4c45a/src/util/fields.py#L258
[_get_domain_fields]: https://github.com/odoo/upgrade-util/blob/3d94a29924f407cdb2c88e2e9fd770746bb4c45a/src/util/domains.py#L157
[domain adaptation]: https://github.com/odoo/upgrade-util/blob/3d94a29924f407cdb2c88e2e9fd770746bb4c45a/src/util/domains.py#L475

opw-6512948
upg-4615689