### PR TITLE
[FIX] util/inherit: hardcode cron/server action inherit

### DIFF
--- a/src/util/inherit.py
+++ b/src/util/inherit.py
@@ -29,15 +29,23 @@ if version_gte("saas~17.1"):
           GROUP BY p.model
         """
         )
-        return frozendict(
-            {
-                parent: [
-                    Inherit(model=model, born=base_version, dead=None, via=via)
-                    for model, via in zip(children, vias, strict=True)
+        data = {
+            parent: [
+                Inherit(model=model, born=base_version, dead=None, via=via)
+                for model, via in zip(children, vias, strict=True)
+            ]
+            for parent, children, vias in cr.fetchall()
+        }
+
+        if not version_gte("saas~18.1"):
+            # `ir.cron`'s delegate=True `ir_actions_server_id` field wasn't
+            # reflected into `ir_model_inherit` until 17.4 https://github.com/odoo/odoo/commit/b70068de0552f87391d885d28d5446e9a81dc7a
+            existing = data.get("ir.actions.server", [])
+            if not any(inh.model == "ir.cron" for inh in existing):
+                data["ir.actions.server"] = existing + [
+                    Inherit(model="ir.cron", born=parse_version("10.saas~14"), dead=None, via="ir_actions_server_id")
                 ]
-                for parent, children, vias in cr.fetchall()
-            }
-        )
+        return frozendict(data)
 
 else:
     from ._inherit import inheritance_data


### PR DESCRIPTION
Inherits are being reflected in `ir_model_inherit` for inherits done via delegate fields from `saas~17.4` since [this patch]. Any DB upgrading from `v17.0` wouldn't have the info until after `base` is loaded. 
There is a new cleanup in [base/0.0.0/pre-] for dangling models from uninstalled modules. When it runs for `v18.0` before loading base, this inherit done via delegate fields is missing from the inheritance data.

In particular, `ir.cron` delegates to `ir.actions.server` via field `ir_actions_server_id` with `delegate=True`.
It didn't have an explicit `_inherits` in the [class] until `v18.2`.

We need to ensure this info is reflected in the inherit info used by `for_each_inherit`.

tbg-[2916]

[class]: https://github.com/odoo/odoo/blob/saas-18.2/odoo/addons/base/models/ir_cron.py#L62-L77
[this patch]: https://github.com/odoo/odoo/commit/b70068de0552f87391d885d28d5446e9a81dc7a
[2916]: https://upgrade.odoo.com/odoo/tbg/2916?debug=1
[base/0.0.0/pre-]: https://github.com/odoo/upgrade/commit/17159b09f883c843fe0201284e7038599bf00e5b