### PR TITLE
[FIX] util/models: wrap removed fields list in a details tag

### DIFF
--- a/src/util/models.py
+++ b/src/util/models.py
@@ -37,7 +37,7 @@ from .pg import (
 # avoid namespace clash
 from .pg import rename_table as pg_rename_table
 from .records import _remove_import_export_paths, _rm_refs, remove_records, remove_view, replace_record_references_batch
-from .report import add_to_migration_reports
+from .report import add_to_migration_reports, html_escape, report_with_list
 
 _logger = logging.getLogger(__name__)
 
@@ -211,13 +211,15 @@ def remove_model(cr, model, drop_table=True, ignore_m2m=()):
                     affected_fields = cr.fetchall()
                     for field, field_model in affected_fields:
                         remove_field(cr, field_model, field, drop_column=False)
-                    msg = "The following fields have been removed because their related model {} ({}) was removed:\n{}".format(
-                        mod_label, model, "\n".join(" - field {} of model {}".format(*r) for r in affected_fields)
+                    msg = "The following fields have been removed because their related model <b>{}</b> ({}) was removed.".format(
+                        html_escape(mod_label), html_escape(model)
                     )
-                    add_to_migration_reports(
-                        message=msg,
+                    report_with_list(
+                        summary=msg,
+                        data=affected_fields,
+                        columns=("name", "model"),
+                        row_format="field <code>{name}</code> of model <code>{model}</code>",
                         category="Removed Fields",
-                        format="md",
                     )
 
             for table_name in tables:


### PR DESCRIPTION
- Wrapped the list of removed fields inside a `<details>` block.
- Aligns the message structure with standard reporting formats.
(worst case) when a db has a large number of remove fields

UPG-4632046

Current behaviour:
<img width="1235" height="114" alt="image" src="https://github.com/user-attachments/assets/6ca93563-5f6d-4d3e-894c-848ecba67dc9" />


After Migration:
<img width="1218" height="119" alt="image" src="https://github.com/user-attachments/assets/139d9af9-ae37-4d75-9c67-c7b33f0378da" />
