### PR TITLE
[FIX] util/indirect_references: set unknown for removing activity type

### DIFF
--- a/src/util/indirect_references.py
+++ b/src/util/indirect_references.py
@@ -70,7 +70,7 @@ INDIRECT_REFERENCES = [
     _IR("iap_extracted_words", "res_model", "res_id"),
     _IR("mail_template", "model", None, set_unknown=True),  # model renamed in saas~6
     _IR("mail_activity", "res_model", "res_id", "res_model_id"),
-    _IR("mail_activity_type", "res_model", None),
+    _IR("mail_activity_type", "res_model", None, set_unknown=True),
     _IR("mail_alias", None, "alias_force_thread_id", "alias_model_id"),
     _IR("mail_alias", None, "alias_parent_thread_id", "alias_parent_model_id"),
     _IR("mail_followers", "res_model", "res_id"),


### PR DESCRIPTION
The `mail.activity.type` model currently has 3 FKs that prevent it from being deleted with `ondelete='restrict'`. They were introduced by the following commits:
- `mail.activity` introduced in [`v12`]
- `ir.actions.server` introduced in [`v14`]
- `mail.activity.plan.template` introduced in [`v16`]

There are failing requests because `mail.activity.type` is an indirect reference/IR for many business models.

The issue mainly arose after the introduction of the new cleanup in [base/0.0.0] for dangling models whose module is in the uninstall stage but whose models are still present in the database.

tbg-[2813]

[`v12`]: https://github.com/odoo/odoo/commit/11f6b294bdcfb82b1493fddf153de60c89df9ebf
[`v14`]: https://github.com/odoo/odoo/commit/0eadc0aa5ea53943738e43b3ec1c9bff3ef30922
[`v16`]: https://github.com/odoo/odoo/commit/35d5342887f14d7863fd362cff2657fb84e00fe8#diff-3af667625cc84ca82075eb87341355ddc18c78ec11682c77a19504df11163506R20-R25
[base/0.0.0]: https://github.com/odoo/upgrade/commit/17159b09f883c843fe0201284e7038599bf00e5b
[2813]: https://upgrade.odoo.com/odoo/tbg/2813?debug=1