### PR TITLE
[FIX] util/models: convert outgoing restrict FKs to SET NULL

### DIFF
--- a/src/util/models.py
+++ b/src/util/models.py
@@ -86,6 +86,46 @@ def remove_model(cr, model, drop_table=True, ignore_m2m=()):
     chunk_size = 1000
     notify = False
     unk_id = _unknown_model_id(cr)
+    table = table_of_model(cr, model)
+    cr.execute(
+        """
+        SELECT con.conname,
+               att.attname,
+               cl2.relname,
+               fatt.attname
+          FROM pg_constraint con
+          JOIN pg_class cl2
+            ON cl2.oid = con.confrelid
+          JOIN pg_attribute att
+            ON att.attrelid = con.conrelid
+           AND att.attnum = con.conkey[1]
+          JOIN pg_attribute fatt
+            ON fatt.attrelid = con.confrelid
+           AND fatt.attnum = con.confkey[1]
+         WHERE con.conrelid = to_regclass(%s)
+           AND con.contype = 'f'
+           AND con.confdeltype IN ('r', 'a')
+           AND array_length(con.conkey, 1) = 1
+        """,
+        [table],
+    )
+    for conname, column, ref_table, ref_col in cr.fetchall():
+        cr.execute(
+            format_query(
+                cr,
+                """
+                ALTER TABLE {table}
+                ALTER COLUMN {column} DROP NOT NULL,
+                 DROP CONSTRAINT {conname},
+                  ADD CONSTRAINT {conname} FOREIGN KEY ({column}) REFERENCES {ref_table}({ref_col}) ON DELETE SET NULL
+                """,
+                table=table,
+                column=column,
+                conname=conname,
+                ref_table=ref_table,
+                ref_col=ref_col,
+            )
+        )
 
     # remove references
     for ir in indirect_references(cr):


### PR DESCRIPTION
`remove_model()` can crash with a FK violation if the model being removed has its own restrict foreign key to something that gets deleted along the way.

**Example:**
- model A has a field `model_id` -> `ir.model`, `ondelete='cascade'`
- model B has a field `a_id` -> model A, `ondelete='restrict'`
- a record of A exists, pointing at model B (via `model_id`)
- a record of B exists, pointing at that same record of A (via `a_id`)

Now call `remove_model(cr, "B")`. To remove model B, it deletes the `ir.model` row for B. Since `A.model_id` is `ondelete='cascade'`, PG automatically deletes the record of A that pointed at B. But that record of A is still referenced by the record of B, through B's own restrict FK `a_id`. PG refuses to delete the A record while that reference still exists.

**Steps to reproduce:**
- Define this in a custom module `mymodule`.
```py
from odoo import fields, models

class A(models.Model):
    _name = "mymodule.a"
    _description = "mymodule.a"

    model_id = fields.Many2one("ir.model", required=True, ondelete="cascade")

class B(models.Model):
    _name = "mymodule.b"
    _description = "mymodule.b"

    a_id = fields.Many2one("mymodule.a", ondelete="restrict")
```
- after installing `mymodule` run this in odoo shell
```py
env = self.env
a = env["mymodule.a"].create({"model_id": env.ref("mymodule.model_mymodule_b").id})
b = env["mymodule.b"].create({"a_id": a.id})

cr = env.cr
util.remove_model(cr, "mymodule.b")
```
- We get the below error:
```sql
2026-09-09 07:34:41,840 150270 ERROR fk_issue_19 odoo.sql_db: bad query: b'DELETE FROM ir_model WHERE id=124'
ERROR: update or delete on table "mymodule_a" violates foreign key constraint "mymodule_b_a_id_fkey" on table "mymodule_b"
DETAIL:  Key (id)=(1) is still referenced from table "mymodule_b".

Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo-bin", line 6, in <module>
    odoo.cli.main()
  File "/home/odoo/src/odoo/19.0/odoo/cli/command.py", line 133, in main
    command().run(args)
  File "/home/odoo/src/odoo/19.0/odoo/cli/shell.py", line 162, in run
    self.shell(dbnames[0])
  File "/home/odoo/src/odoo/19.0/odoo/cli/shell.py", line 148, in shell
    self.console(local_vars)
  File "/home/odoo/src/odoo/19.0/odoo/cli/shell.py", line 82, in console
    exec(sys.stdin.read(), local_vars)
  File "<string>", line 8, in <module>
  File "/home/odoo/src/upgrade/migrations/util/models.py", line 258, in remove_model
    cr.execute("DELETE FROM ir_model WHERE id=%s", (mod_id,))
  File "/home/odoo/src/odoo/19.0/odoo/sql_db.py", line 440, in execute
    self._obj.execute(query, params)
psycopg2.errors.ForeignKeyViolation: update or delete on table "mymodule_a" violates foreign key constraint "mymodule_b_a_id_fkey" on table "mymodule_b"
DETAIL:  Key (id)=(1) is still referenced from table "mymodule_b".
```

**Note:** The above case is not reproducible if model B inherits from model A, as that case is already handled correctly.