### PR TITLE
[FIX] pg: Trim long constraint names

### DIFF
--- a/src/util/pg.py
+++ b/src/util/pg.py
@@ -46,6 +46,16 @@ from .exceptions import MigrationError, SleepyDeveloperError
 from .helpers import _validate_table, model_of_table
 from .misc import AUTO, Sentinel, get_max_workers, log_progress, on_CI, version_gte
 
+try:
+    from odoo.tools.sql import make_identifier
+except ImportError:
+    if version_gte("17.0"):
+        raise
+
+    def make_identifier(identifier):
+        return identifier
+
+
 __all__ = [
     "ColumnList",
     "IndexInfo",
@@ -1567,7 +1577,7 @@ def rename_table(cr, old_table, new_table, remove_constraints=True):
     )
     old_table_length = len(old_table)
     for (old_const,) in cr.fetchall():
-        new_const = new_table + old_const[old_table_length:]
+        new_const = make_identifier(new_table + old_const[old_table_length:])
         _logger.info("Renaming constraint %r to %r", old_const, new_const)
         cr.execute(
             sql.SQL("ALTER TABLE {} RENAME CONSTRAINT {} TO {}").format(


### PR DESCRIPTION
Since the limit for object names is 64 characters, it could happen that two constraints get truncated to the same name and the upgrade fails.

The util [pg.make_identifier](https://github.com/odoo/odoo/blob/e809d194b885d515c6c977346a02b385d232b53b/odoo/tools/sql.py#L800-L809) was added in 17, so it's directly imported. For earlier versions the same logic is applied to try to stay coherent to the ORM behaviour.

This error happens now while try to rename the constrains from an m2m table: https://github.com/odoo/upgrade/blob/master/migrations/stock/saas~19.5.1.1/pre-migrate.py#L46
```
2026-09-09 13:52:32,753 1076222 INFO test_stock_master odoo.modules.migration: module stock: Running upgrade [>saas~19.5.1.1] pre-migrate
2026-09-09 13:52:33,768 1076222 INFO test_stock_master odoo.upgrade.util.pg: Renaming constraint 'Products_stock_package_destination_id_not_null' to 'stock_move_line_stock_package_destination_rel_stock_package_destinatio>
2026-09-09 13:52:33,769 1076222 INFO test_stock_master odoo.upgrade.util.pg: Renaming constraint 'Products_stock_move_line_id_not_null' to 'stock_move_line_stock_package_destination_rel_stock_move_line_id_not_null'
2026-09-09 13:52:33,769 1076222 INFO test_stock_master odoo.upgrade.util.pg: Renaming constraint 'Products_stock_package_destination_id_fkey' to 'stock_move_line_stock_package_destination_rel_stock_package_destination_id>
2026-09-09 13:52:33,775 1076222 ERROR test_stock_master odoo.sql_db: bad query: b'ALTER TABLE "stock_move_line_stock_package_destination_rel" RENAME CONSTRAINT "Products_stock_package_destination_id_fkey" TO "stock_move_>
ERROR: constraint "stock_move_line_stock_package_destination_rel_stock_package_des" for relation "stock_move_line_stock_package_destination_rel" already exists

2026-09-09 13:52:33,776 1076222 WARNING test_stock_master odoo.modules.loading: Transient module states were reset
2026-09-09 13:52:33,784 1076222 ERROR test_stock_master odoo.registry: Failed to load registry
2026-09-09 13:52:33,784 1076222 CRITICAL test_stock_master odoo.service.server: Failed to initialize database `test_stock_master`.
Traceback (most recent call last):
  File "/home/odoo/src/odoo/master/odoo/service/server.py", line 1559, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/master/odoo/tools/func.py", line 67, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/master/odoo/orm/registry.py", line 222, in new
    contextvars.Context().run(
  File "/home/odoo/src/odoo/master/odoo/modules/loading.py", line 446, in load_modules
    load_module_graph(
  File "/home/odoo/src/odoo/master/odoo/modules/loading.py", line 168, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/home/odoo/src/odoo/master/odoo/modules/migration.py", line 218, in migrate_module
    exec_script(self.cr, installed_version, pyfile, pkg.name, stage, version)
  File "/home/odoo/src/odoo/master/odoo/modules/migration.py", line 268, in exec_script
    mod.migrate(cr, installed_version)
  File "/home/odoo/src/upgrade/migrations/stock/saas~19.5.1.1/pre-migrate.py", line 46, in migrate
    util.rename_table(cr, "Products", "stock_move_line_stock_package_destination_rel")
  File "/home/odoo/src/upgrade-util/src/util/pg.py", line 1572, in rename_table
    cr.execute(
  File "/home/odoo/src/odoo/master/odoo/sql_db.py", line 418, in execute
    self._obj.execute(query, params)
psycopg2.errors.DuplicateObject: constraint "stock_move_line_stock_package_destination_rel_stock_package_des" for relation "stock_move_line_stock_package_destination_rel" already exists

```